### PR TITLE
Support for ruamel.yaml

### DIFF
--- a/box.py
+++ b/box.py
@@ -22,7 +22,11 @@ try:
     import yaml
     yaml_support = True
 except ImportError:
-    yaml = None
+    try:
+        import ruamel.yaml as yaml
+        yaml_support = True
+    except ImportError:
+        yaml = None
 
 if sys.version_info >= (3, 0):
     basestring = str


### PR DESCRIPTION
Module ``ruamel.yaml`` is quite a common alternative to PyYAML, and is a drop-in replacement in nearly every case. See https://yaml.readthedocs.io/en/latest/pyyaml.html for more information. 