### PR TITLE
Delete custom __contains__ and use the dict\'s default __contains__. …

### DIFF
--- a/box.py
+++ b/box.py
@@ -376,9 +376,6 @@ class Box(dict):
 
         return list(items)
 
-    def __contains__(self, item):
-        return dict.__contains__(self, item) or hasattr(self, item)
-
     def copy(self):
         return self.__class__(super(self.__class__, self).copy())
 


### PR DESCRIPTION
Delete custom __contains__ and use the dict\'s default __contains__. The current __contains__ function is buggy for default_box. It always returns True