### PR TITLE
Bug/camel killer conflicts

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,7 +9,7 @@ Code contributions:
 - dhilipsiva (dhilipsiva)
 - MAA (FooBarQuaxx)
 - Jiang Chen (criver)
-- Matan Rosenberh (matan129)
+- Matan Rosenberg (matan129)
 
 Suggestions and bug reporting:
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Code contributions:
 - dhilipsiva (dhilipsiva)
 - MAA (FooBarQuaxx)
 - Jiang Chen (criver)
+- Matan Rosenberh (matan129)
 
 Suggestions and bug reporting:
 

--- a/box.py
+++ b/box.py
@@ -411,16 +411,7 @@ class Box(dict):
             if item == '_box_config':
                 raise BoxError('_box_config key must exist and does not. '
                                'This is most likely a bug, please report.')
-            default_value = self._box_config['default_box_attr']
-            if self._box_config['default_box']:
-                if default_value is self.__class__:
-                    return self.__class__(__box_heritage=(self, item),
-                                          **self.__box_config())
-                elif isinstance(default_value, collections.Callable):
-                    return default_value()
-                elif hasattr(default_value, 'copy'):
-                    return default_value.copy()
-                return default_value
+
             raise BoxKeyError(str(err))
         else:
             return self.__convert_and_store(item, value)
@@ -471,7 +462,7 @@ class Box(dict):
         if (self._box_config['__box_heritage'] and
                 self._box_config['__created']):
             past, item = self._box_config['__box_heritage']
-            if not past[item]:
+            if item not in past:
                 past[item] = self
             self._box_config['__box_heritage'] = None
 
@@ -487,6 +478,7 @@ class Box(dict):
             except KeyError:
                 if item == '_box_config':
                     raise BoxError('_box_config key must exist')
+
                 kill_camel = self._box_config['camel_killer_box']
                 if self._box_config['conversion_box'] and item:
                     k = _conversion_checks(item, self.keys(), self._box_config)
@@ -496,6 +488,17 @@ class Box(dict):
                     for k in self.keys():
                         if item == _camel_killer(k):
                             return self.__getitem__(k)
+
+                default_value = self._box_config['default_box_attr']
+                if self._box_config['default_box']:
+                    if default_value is self.__class__:
+                        return self.__class__(__box_heritage=(self, item),
+                                              **self.__box_config())
+                    elif isinstance(default_value, collections.Callable):
+                        return default_value()
+                    elif hasattr(default_value, 'copy'):
+                        return default_value.copy()
+                    return default_value
             raise BoxKeyError(str(err))
         else:
             if item == '_box_config':

--- a/box.py
+++ b/box.py
@@ -473,32 +473,30 @@ class Box(dict):
             except KeyError:
                 value = object.__getattribute__(self, item)
         except AttributeError as err:
-            try:
-                return self.__getitem__(item)
-            except KeyError:
-                if item == '_box_config':
-                    raise BoxError('_box_config key must exist')
+            if item == '_box_config':
+                raise BoxError('_box_config key must exist')
 
-                kill_camel = self._box_config['camel_killer_box']
-                if self._box_config['conversion_box'] and item:
-                    k = _conversion_checks(item, self.keys(), self._box_config)
-                    if k:
+            kill_camel = self._box_config['camel_killer_box']
+            if self._box_config['conversion_box'] and item:
+                k = _conversion_checks(item, self.keys(), self._box_config)
+                if k:
+                    return self.__getitem__(k)
+            if kill_camel:
+                for k in self.keys():
+                    if item == _camel_killer(k):
                         return self.__getitem__(k)
-                if kill_camel:
-                    for k in self.keys():
-                        if item == _camel_killer(k):
-                            return self.__getitem__(k)
 
-                default_value = self._box_config['default_box_attr']
-                if self._box_config['default_box']:
-                    if default_value is self.__class__:
-                        return self.__class__(__box_heritage=(self, item),
-                                              **self.__box_config())
-                    elif isinstance(default_value, collections.Callable):
-                        return default_value()
-                    elif hasattr(default_value, 'copy'):
-                        return default_value.copy()
-                    return default_value
+            default_value = self._box_config['default_box_attr']
+            if self._box_config['default_box']:
+                if default_value is self.__class__:
+                    return self.__class__(__box_heritage=(self, item),
+                                          **self.__box_config())
+                elif isinstance(default_value, collections.Callable):
+                    return default_value()
+                elif hasattr(default_value, 'copy'):
+                    return default_value.copy()
+                return default_value
+
             raise BoxKeyError(str(err))
         else:
             if item == '_box_config':

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -355,6 +355,17 @@ class TestBoxFunctional(unittest.TestCase):
         assert con_kill_box.camel_case == 'Item'
         assert con_kill_box.x321_camel_case_fever == 'Safe'
 
+        with pytest.raises(BoxKeyError):
+            assert con_kill_box.CamelCase
+
+    def test_default_and_camel_killer_box(self):
+        td = extended_test_dict.copy()
+        td['CamelCase'] = 'Item'
+
+        killer_default_box = Box(td, camel_killer_box=True, default_box=True)
+
+        assert killer_default_box.camel_case == 'Item'
+
     def test_property_box(self):
         td = test_dict.copy()
         td['inner'] = {'CamelCase': 'Item'}

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -355,9 +355,6 @@ class TestBoxFunctional(unittest.TestCase):
         assert con_kill_box.camel_case == 'Item'
         assert con_kill_box.x321_camel_case_fever == 'Safe'
 
-        with pytest.raises(BoxKeyError):
-            assert con_kill_box.CamelCase
-
     def test_default_and_camel_killer_box(self):
         td = extended_test_dict.copy()
         td['CamelCase'] = 'Item'


### PR DESCRIPTION
Partially solves #46 .
I have limited time today so I only fixed the `default_box` + `camel_killer` issue.

Now, "camel-killed" attributes will be looked up before the `default_box` logic is used.

I've added regression test for this case. 