### PR TITLE
Feature Request: "BoxObject" — Wrapper for Objects with __dict__ as a Box

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ Code contributions:
 - Matt Wisniewski (polishmatt)
 - Martijn Pieters (mjpieters)
 - (sdementen)
+- Brandon Gomes (bhgomes)
 
 Suggestions and bug reporting:
 

--- a/README.rst
+++ b/README.rst
@@ -406,6 +406,46 @@ config values into python types. It supports `list`, `bool`, `int` and `float`.
     config.Examples.float('floatly')
     # 4.4
 
+BoxObject
+---------
+
+An object wrapper with a **Box** for a **__dict__**.
+
+.. code:: python
+
+    import requests
+    from box import BoxObject
+
+    def get_html(session, url, *args, **kwargs):
+        response = session.get(url, *args, **kwargs)
+        text = response.text
+        response_meta = response.__dict__
+        for key in tuple(filter(lambda k: k.startswith('_'), response_meta)):
+            response_meta.pop(key)
+        return BoxObject(text, response_meta, frozen_box=True)
+
+    box_url = 'https://raw.githubusercontent.com/cdgriffith/Box/master/box.py'
+    with requests.Session() as session:
+        box_source = get_html(session, box_url)
+
+    box_source.url
+    # https://raw.githubusercontent.com/cdgriffith/Box/master/box.py
+
+    box_source.status_code
+    # 200
+
+    box_source.raw.reason
+    # OK
+
+**BoxObject**s act just like objects but they secretly carry around a **Box** with
+them to store attributes. **BoxObject**s are built off of **wrapt.ObjectProxy**s which
+can wrap almost any python object. They protect their wrapped objects storing them in
+the **__wrapped__** attribute and keeping the original **__dict__** in
+**__wrapped__.__dict__**.
+
+See the `Wrapt Documentation <https://wrapt.readthedocs.io/en/latest\>`_, specifically
+the section on **ObjectProxy**s, for more information.
+
 
 License
 =======

--- a/box.py
+++ b/box.py
@@ -1158,11 +1158,11 @@ if wrapt_support:
             """Get Attribute from Wrapped Object or from Box."""
             try:
                 return super(BoxObject, self).__getattr__(name)
-            except AttributeError:
+            except AttributeError as error:
                 try:
                     return self.__dict__[name]
                 except KeyError:
-                    raise AttributeError(name)
+                    raise error
 
         def __setattr__(self, name, value):
             """Set Attribute in Wrapped Object or Box."""

--- a/box.py
+++ b/box.py
@@ -1180,9 +1180,13 @@ if wrapt_support:
                     '__dict__',
                     getattr(self.__wrapped__, '__dict__', {})
                 )
-            elif hasattr(self.__wrapped__, name):
-                delattr(self.__wrapped__, name)
             else:
-                del self.__dict__[name]
+                try:
+                    delattr(self.__wrapped__, name)
+                except AttributeError as error:
+                    try:
+                        del self.__dict__[name]
+                    except KeyError:
+                        raise error
 
     __all__ += ['BoxObject']

--- a/box.py
+++ b/box.py
@@ -1175,10 +1175,13 @@ if wrapt_support:
 
         def __delattr__(self, name):
             """Delete Attribute in Wrapped Object or Box."""
-            if hasattr(self.__wrapped__, name):
+            if name == '__dict__':
+                super(BoxObject, self).__setattr__(
+                    '__dict__',
+                    getattr(self.__wrapped__, '__dict__', {})
+                )
+            elif hasattr(self.__wrapped__, name):
                 delattr(self.__wrapped__, name)
-            elif name == '__dict__':
-                super(BoxObject, self).__setattr__('__dict__', {})
             else:
                 del self.__dict__[name]
 

--- a/box.py
+++ b/box.py
@@ -1159,7 +1159,10 @@ if wrapt_support:
             try:
                 return super(BoxObject, self).__getattr__(name)
             except AttributeError:
-                return self.__dict__[name]
+                try:
+                    return self.__dict__[name]
+                except KeyError:
+                    raise AttributeError(name)
 
         def __setattr__(self, name, value):
             """Set Attribute in Wrapped Object or Box."""

--- a/box.py
+++ b/box.py
@@ -1141,18 +1141,17 @@ if wrapt_support:
         def __init__(self, wrapped=None, *args, **kwargs):
             """Initialize Box Object with __dict__ as a Box."""
             super(BoxObject, self).__init__(wrapped)
+            box_class = kwargs.pop('box_class', Box)
             try:
                 base_dict = super(BoxObject, self).__getattr__('__dict__')
                 if args:
                     raise TypeError('Cannot pass dictionary arguments when '
                                     'internal object has __dict__ attributes. '
                                     'Pass arguments by keyword instead.')
+                box = box_class(base_dict, **kwargs)
             except AttributeError:
-                base_dict = args
-            box_class = kwargs.pop('box_class', Box)
-            super(BoxObject, self).__setattr__(
-                '__dict__', box_class(base_dict, **kwargs)
-            )
+                box = box_class(*args, **kwargs)
+            super(BoxObject, self).__setattr__('__dict__', box)
 
         def __call__(self, *args, **kwargs):
             """Call Method for Callable Objects."""

--- a/box.py
+++ b/box.py
@@ -1168,5 +1168,14 @@ if wrapt_support:
             else:
                 self.__dict__[name] = value
 
+        def __delattr__(self, name):
+            """Delete Attribute in Wrapped Object or Box."""
+            if hasattr(self.__wrapped__, name):
+                delattr(self.__wrapped__, name)
+            elif name == '__dict__':
+                super().__setattr__('__dict__', {})
+            else:
+                del self.__dict__[name]
+
 
     __all__ += ['BoxObject']

--- a/box.py
+++ b/box.py
@@ -1135,19 +1135,23 @@ if wrapt_support:
 
         :param wrapped: Wrapped Object.
         :param box_class: Custom internal Box class
-        :param args: Arguments to box_class
-        :param kwargs: Keyword arguments to box_class
+        :param kwargs: Keyword arguments to fill Box
         """
 
-        def __init__(self, wrapped=None, box_class=Box, *args, **kwargs):
+        def __init__(self, wrapped=None, *args, **kwargs):
             """Initialize Box Object with __dict__ as a Box."""
             super(BoxObject, self).__init__(wrapped)
             try:
                 base_dict = super(BoxObject, self).__getattr__('__dict__')
+                if args:
+                    raise TypeError('Cannot pass dictionary arguments when '
+                                    'internal object has __dict__ attributes. '
+                                    'Pass arguments by keyword instead.')
             except AttributeError:
-                base_dict = {}
+                base_dict = args
+            box_class = kwargs.pop('box_class', Box)
             super(BoxObject, self).__setattr__(
-                '__dict__', box_class(base_dict, *args, **kwargs)
+                '__dict__', box_class(base_dict, **kwargs)
             )
 
         def __call__(self, *args, **kwargs):

--- a/box.py
+++ b/box.py
@@ -1124,8 +1124,19 @@ if wrapt_support:
 
     class BoxObject(wrapt.ObjectProxy):
         """
-        Box Object.
+        Wrapper for any Python object with a Box as __dict__.
 
+        Simple Usage:
+
+        import requests
+        url = 'https://raw.githubusercontent.com/cdgriffith/Box/master/box.py'
+        session = BoxObject(requests.Session())
+        session.source_code = session.get(url).text
+
+        :param wrapped: Wrapped Object.
+        :param box_class: Custom internal Box class
+        :param args: Arguments to box_class
+        :param kwargs: Keyword arguments to box_class
         """
 
         def __init__(self, wrapped=None, box_class=Box, *args, **kwargs):
@@ -1138,7 +1149,7 @@ if wrapt_support:
             super().__setattr__('__dict__', box_class(base_dict, *args, **kwargs))
 
         def __call__(self, *args, **kwargs):
-            """Wrapper for Callable Objects."""
+            """Call Method for Callable Objects."""
             return self.__wrapped__(*args, **kwargs)
 
         def __getattr__(self, name):

--- a/box.py
+++ b/box.py
@@ -1135,6 +1135,7 @@ if wrapt_support:
 
         :param wrapped: Wrapped Object.
         :param box_class: Custom internal Box class
+        :param args: Arguments to fill Box
         :param kwargs: Keyword arguments to fill Box
         """
 

--- a/box.py
+++ b/box.py
@@ -1179,5 +1179,4 @@ if wrapt_support:
             else:
                 del self.__dict__[name]
 
-
     __all__ += ['BoxObject']

--- a/box.py
+++ b/box.py
@@ -1146,8 +1146,9 @@ if wrapt_support:
                 base_dict = super(BoxObject, self).__getattr__('__dict__')
             except AttributeError:
                 base_dict = {}
-            super(BoxObject, self).__setattr__('__dict__',
-                                               box_class(base_dict, *args, **kwargs))
+            super(BoxObject, self).__setattr__(
+                '__dict__', box_class(base_dict, *args, **kwargs)
+            )
 
         def __call__(self, *args, **kwargs):
             """Call Method for Callable Objects."""

--- a/box.py
+++ b/box.py
@@ -29,13 +29,16 @@ except ImportError:
         yaml = None
         yaml_support = False
 
+
+wrapt_support = True
+
 try:
     import wrapt
-    wrapt_support = True
 except ImportError:
+    wrapt = None
     wrapt_support = False
 
-    
+
 if sys.version_info >= (3, 0):
     basestring = str
 else:
@@ -1116,15 +1119,16 @@ class SBox(Box):
     def __repr__(self):
         return '<ShorthandBox: {0}>'.format(str(self.to_dict()))
 
-    
+
 if wrapt_support:
+
     class BoxObject(wrapt.ObjectProxy):
         """
         Box Object.
-    
+
         """
 
-        def __init__(self, wrapped, *args, box_class=box.Box, **kwargs):
+        def __init__(self, wrapped=None, box_class=Box, *args, **kwargs):
             """Initialize Box Object with __dict__ as a Box."""
             super().__init__(wrapped)
             try:
@@ -1152,5 +1156,6 @@ if wrapt_support:
                 raise TypeError('cannot set __dict__')
             else:
                 self.__dict__[name] = value
-    
-    __all__  += ['BoxObject']
+
+
+    __all__ += ['BoxObject']

--- a/box.py
+++ b/box.py
@@ -1166,10 +1166,10 @@ if wrapt_support:
 
         def __setattr__(self, name, value):
             """Set Attribute in Wrapped Object or Box."""
-            if hasattr(self.__wrapped__, name):
-                setattr(self.__wrapped__, name, value)
-            elif name == '__dict__':
+            if name == '__dict__':
                 raise TypeError('cannot set __dict__')
+            elif hasattr(self.__wrapped__, name):
+                setattr(self.__wrapped__, name, value)
             else:
                 self.__dict__[name] = value
 

--- a/box.py
+++ b/box.py
@@ -1141,12 +1141,13 @@ if wrapt_support:
 
         def __init__(self, wrapped=None, box_class=Box, *args, **kwargs):
             """Initialize Box Object with __dict__ as a Box."""
-            super().__init__(wrapped)
+            super(BoxObject, self).__init__(wrapped)
             try:
-                base_dict = super().__getattr__('__dict__')
+                base_dict = super(BoxObject, self).__getattr__('__dict__')
             except AttributeError:
                 base_dict = {}
-            super().__setattr__('__dict__', box_class(base_dict, *args, **kwargs))
+            super(BoxObject, self).__setattr__('__dict__',
+                                               box_class(base_dict, *args, **kwargs))
 
         def __call__(self, *args, **kwargs):
             """Call Method for Callable Objects."""
@@ -1155,7 +1156,7 @@ if wrapt_support:
         def __getattr__(self, name):
             """Get Attribute from Wrapped Object or from Box."""
             try:
-                return super().__getattr__(name)
+                return super(BoxObject, self).__getattr__(name)
             except AttributeError:
                 return self.__dict__[name]
 
@@ -1173,7 +1174,7 @@ if wrapt_support:
             if hasattr(self.__wrapped__, name):
                 delattr(self.__wrapped__, name)
             elif name == '__dict__':
-                super().__setattr__('__dict__', {})
+                super(BoxObject, self).__setattr__('__dict__', {})
             else:
                 del self.__dict__[name]
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ coverage >= 4.5.2
 pytest-cov
 PyYAML; python_version <= '3.3'
 ruamel.yaml; python_version >= '3.4'
-python-box
+wrapt
 addict
 dotmap
 reusables

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@ coverage >= 4.5.2
 pytest-cov
 PyYAML; python_version <= '3.3'
 ruamel.yaml; python_version >= '3.4'
+python-box
 addict
 dotmap
 reusables

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -776,6 +776,9 @@ def test_box_object_attributes():
         assert getattr(b, tagged) == [v]
         setattr(b, k, getattr(b, tagged))
         assert getattr(b, k) == [v]
+    for k, v in test_dict.items():
+        assert k in b
+        assert b[k] == v
 
 
 def mp_queue_test(q):

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -775,6 +775,15 @@ def test_box_object_generic(wrapped):
     assert b.__dict__ != getattr(b.__wrapped__, '__dict__', None)
 
 
+@pytest.mark.parametrize('wrapped', python_example_objects)
+def test_box_object_deletion(wrapped):
+    b = BoxObject(wrapped)
+    with pytest.raises(TypeError):
+        b.__dict__ = 0
+    del b.__dict__
+    assert b.__dict__ == {}
+
+
 def test_box_object_attributes():
     b = BoxObject(test_dict, **movie_data)
     assert b == test_dict

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -780,6 +780,11 @@ def test_box_object_generic(wrapped):
     assert 'box_key' in b.__dict__
     assert isinstance(b.__dict__, Box)
     assert b.__dict__ != getattr(b.__wrapped__, '__dict__', None)
+    with pytest.raises(AttributeError):
+        b.foo
+    if hasattr(b.__wrapped__, 'b'):
+        b.b = 1
+        assert b.__wrapped__.b == 1
 
 
 @pytest.mark.parametrize('wrapped', python_example_objects)
@@ -815,6 +820,10 @@ def test_box_object_attributes():
     for k, v in test_dict.items():
         assert k in b
         assert b[k] == v
+
+
+def test_box_object_call():
+    assert True
 
 
 def mp_queue_test(q):

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -762,6 +762,7 @@ def test_box_object_generic(wrapped):
     assert b.box_key == 'secret_word'
     assert 'box_key' in b.__dict__
     assert isinstance(b.__dict__, Box)
+    assert b.__dict__ != getattr(b.__wrapped__, '__dict__', None)
 
 
 def test_box_object_attributes():
@@ -769,6 +770,8 @@ def test_box_object_attributes():
     assert b == test_dict
     assert not (b is test_dict)
     assert b.__dict__ == movie_data
+    assert isinstance(b.__dict__, Box)
+    assert b.__dict__ != getattr(b.__wrapped__, '__dict__', None)
     for k, v in movie_data.items():
         assert getattr(b, k) == v
         tagged = k + '_b'

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -829,6 +829,11 @@ def test_box_object_call():
     assert b(list(test_dict), **movie_data) == f(list(test_dict), **movie_data)
 
 
+def test_box_object_double_args():
+    with pytest.raises(TypeError):
+        BoxObject(_f, zip([1, 2, 3], [4, 5, 6]), **movie_data)
+
+
 def mp_queue_test(q):
     bx = q.get()
     try:

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -747,7 +747,17 @@ def _f(value):
 
 
 python_example_objects = (
-    None, True, False, 1, 3.14, 'abc', [1, 2, 3], {}, ([], {}), lambda x: x**2, _f
+    None,
+    True,
+    False,
+    1,
+    3.14,
+    'abc',
+    [1, 2, 3],
+    {},
+    ([], {}),
+    lambda x: x**2,
+    _f
 )
 
 

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -823,7 +823,10 @@ def test_box_object_attributes():
 
 
 def test_box_object_call():
-    assert True
+    def f(*args, **kwargs):
+        return (args, kwargs)
+    b = BoxObject(f)
+    assert b(list(test_dict), **movie_data) == f(list(test_dict), **movie_data)
 
 
 def mp_queue_test(q):

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -742,6 +742,42 @@ class TestBoxFunctional(unittest.TestCase):
         assert bl == [['foo']], bl
 
 
+def _f(value):
+    yield value
+
+
+python_example_objects = (
+    None, True, False, 1, 3.14, 'abc', [1, 2, 3], {}, ([], {}), lambda x: x**2, _f
+)
+
+
+@pytest.mark.parametrize('wrapped', python_example_objects)
+def test_box_object_generic(wrapped):
+    b = BoxObject(wrapped)
+    assert b == wrapped
+    assert not (b is wrapped)
+    assert isinstance(b, BoxObject)
+    assert isinstance(b, type(wrapped))
+    b.box_key = 'secret_word'
+    assert b.box_key == 'secret_word'
+    assert 'box_key' in b.__dict__
+    assert isinstance(b.__dict__, Box)
+
+
+def test_box_object_attributes():
+    b = BoxObject(test_dict, **movie_data)
+    assert b == test_dict
+    assert not (b is test_dict)
+    assert b.__dict__ == movie_data
+    for k, v in movie_data.items():
+        assert getattr(b, k) == v
+        tagged = k + '_b'
+        setattr(b, tagged, [v])
+        assert getattr(b, tagged) == [v]
+        setattr(b, k, getattr(b, tagged))
+        assert getattr(b, k) == [v]
+
+
 def mp_queue_test(q):
     bx = q.get()
     try:

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -746,6 +746,12 @@ def _f(value):
     yield value
 
 
+class _C(object):
+    def __init__(self):
+        self.a = 'a'
+        self.b = 2
+
+
 python_example_objects = (
     None,
     True,
@@ -757,7 +763,8 @@ python_example_objects = (
     {},
     ([], {}),
     lambda x: x**2,
-    _f
+    _f,
+    _C()
 )
 
 
@@ -781,7 +788,14 @@ def test_box_object_deletion(wrapped):
     with pytest.raises(TypeError):
         b.__dict__ = 0
     del b.__dict__
-    assert b.__dict__ == {}
+    assert b.__dict__ == getattr(b.__wrapped__, '__dict__', {})
+    with pytest.raises(AttributeError):
+        del b.foo
+    if hasattr(b.__wrapped__, 'a'):
+        del b.a
+    if not hasattr(b.__wrapped__, 'b'):
+        with pytest.raises(AttributeError):
+            del b.b
 
 
 def test_box_object_attributes():


### PR DESCRIPTION
In this feature request, I am proposing a generic extension to the `wrapt.ObjectProxy` which attaches a `Box` as a replacement for the internal `__dict__` for any wrappable object. Features added:

- **_Fully Optional_**: The inclusion of this feature depends on the user's environment. The functionality will only be added if the user has `wrapt` in their Python environment, just like the `yaml` support.
- **_Doesn't Replace `BoxList`_**: Since `BoxList` adds its elements as `Box`es and not as generic objects the elements of `BoxObject([])` are not the same as `BoxList`. Both of these objects serve different goals.
- **_Adds Boxes Everywhere_**: Now that any object can be a `Box`, even a function, properties can be very easily added to anything; Boxes can now be used more uniformly throughout a project.
- **_Preserves Wrapped Object_**: 
    - If the wrapped object had its own `__dict__` it is preserved in `self.__wrapped__.__dict__`
    - Attributes of the underlying object can be retrieved or modified, but any attributes added after wrapping are kept in the box according to the `Box`'s specification. Attributes can be directly added to the wrapped object via `self.__wrapped__.{attribute} = {value}`.
    - Internal Box can be removed anytime via `del self.__dict__`.
- **_Extends Conventional Free Attribute Modification_**: Python already allows you to add attributes to most objects (but not things like `list`s and `int`), but now anything can have an attribute and you also get to use all of the wonderful properties of `Box`es.

I hope this new feature is in alignment with the goals of the `Box` project and that it is added as an extension of the main library.

---

Questions for @cdgriffith:
1. If this is not meant to be merged in `master`, what branch should I pull request from?
2. Are there enough tests?
3. Is there enough documentation? Should the user be sent to `wrapt` to get more thorough information on the wrapping properties?
4. Should it be called be `ObjectBox` instead?
5. Should the `__dict__` be "settable", in other words, should something like `self.__dict__ = 1` work or should it raise an exception? Currently the code reads:

```python
def __setattr__(self, name, value):
    """Set Attribute in Wrapped Object or Box."""
    if hasattr(self.__wrapped__, name):
        setattr(self.__wrapped__, name, value)
    elif name == '__dict__':
        raise TypeError('cannot set __dict__')
    else:
        self.__dict__[name] = value
```

but it could also be implemented as `super().__setattr__('__dict__', value)` instead of the `TypeError`.