### PR TITLE
Allow .get(default=None) with defaultbox

### DIFF
--- a/box.py
+++ b/box.py
@@ -55,6 +55,9 @@ BOX_PARAMETERS = ('default_box', 'default_box_attr', 'conversion_box',
 _first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 _all_cap_re = re.compile('([a-z0-9])([A-Z])')
 
+# a sentinel object for indicating no default, in order to allow users to pass `None` as a
+# valid default value
+NO_DEFAULT = object()
 
 class BoxError(Exception):
     """Non standard dictionary exceptions"""
@@ -390,9 +393,9 @@ class Box(dict):
 
         return list(items)
 
-    def get(self, key, default=None):
+    def get(self, key, default=NO_DEFAULT):
         if key not in self:
-            if default is None and self._box_config['default_box']:
+            if default is NO_DEFAULT and self._box_config['default_box']:
                 return self.__get_default(key)
             if isinstance(default, dict) and not isinstance(default, Box):
                 return Box(default)

--- a/box.py
+++ b/box.py
@@ -55,8 +55,8 @@ BOX_PARAMETERS = ('default_box', 'default_box_attr', 'conversion_box',
 _first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 _all_cap_re = re.compile('([a-z0-9])([A-Z])')
 
-# a sentinel object for indicating no default, in order to allow users to pass `None` as a
-# valid default value
+# a sentinel object for indicating no default, in order to allow users
+# to pass `None` as a valid default value
 NO_DEFAULT = object()
 
 class BoxError(Exception):


### PR DESCRIPTION
This is a small tweak, but you can't pass `None` as the default value when calling `get` on a DefaultBox. It interprets `None` as "not specifying a default" instead of "the default value I want" and returns a new DefaultBox. A quick solution is to use a sentinel `object` instead of `None`. 


```
import box

b = box.Box()
b.get('x', None) # None
```