### PR TITLE
fix: make frozen box deep copyable

### DIFF
--- a/box.py
+++ b/box.py
@@ -411,11 +411,15 @@ class Box(dict):
         return Box(super(Box, self).copy())
 
     def __deepcopy__(self, memodict=None):
-        out = self.__class__(**self.__box_config())
+        frozen = self._box_config['frozen_box']
+        config = self.__box_config()
+        config['frozen_box'] = False
+        out = self.__class__(**config)
         memodict = memodict or {}
         memodict[id(self)] = out
         for k, v in self.items():
             out[copy.deepcopy(k, memodict)] = copy.deepcopy(v, memodict)
+        out._box_config['frozen_box'] = frozen
         return out
 
     def __setstate__(self, state):

--- a/test/test_functional_box.py
+++ b/test/test_functional_box.py
@@ -609,6 +609,15 @@ class TestBoxFunctional(unittest.TestCase):
         assert dd == copy.copy(dd)
         assert isinstance(copy.copy(dd), BoxList)
 
+    def test_deepcopy_of_frozen_box(self):
+        my_box = Box(data={'a': movie_data,
+                           'b': Box(movie_data, frozen_box=True)},
+                     frozen_box=True)
+        aa = copy.deepcopy(my_box)
+        assert my_box == aa
+        assert id(my_box) != id(aa)
+        assert isinstance(aa, Box)
+
     def test_custom_key_errors(self):
         my_box = Box()
 


### PR DESCRIPTION
Currently, deepcopy on a frozen box raises an error:

```python
>>> import copy
>>> from box import Box
>>> b=Box(data={'a':1}, frozen_box=True)
>>> bb=copy.deepcopy(b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.7/copy.py", line 161, in deepcopy
    y = copier(memo)
  File "/home/jdelgado/src/Box/box.py", line 415, in __deepcopy__
    out[copy.deepcopy(k, memodict)] = copy.deepcopy(v, memodict)
  File "/usr/lib64/python3.7/copy.py", line 161, in deepcopy
    y = copier(memo)
  File "/home/jdelgado/src/Box/box.py", line 415, in __deepcopy__
    out[copy.deepcopy(k, memodict)] = copy.deepcopy(v, memodict)
  File "/home/jdelgado/src/Box/box.py", line 534, in __setitem__
    raise BoxError('Box is frozen')
box.BoxError: Box is frozen
```

This PR provides a fix.