### PR TITLE
Fix issue when calling .get() from non-default box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.mypy_cache/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/box/box.py
+++ b/box/box.py
@@ -22,11 +22,10 @@ __all__ = ['Box']
 
 _first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 _all_cap_re = re.compile('([a-z0-9])([A-Z])')
-NO_DEFAULT = object()
-
 
 # a sentinel object for indicating no default, in order to allow users
 # to pass `None` as a valid default value
+NO_DEFAULT = object()
 
 
 def _safe_attr(attr, camel_killer=False, replacement_char='x'):
@@ -282,10 +281,14 @@ class Box(dict):
 
     def get(self, key, default=NO_DEFAULT):
         if key not in self:
-            if (default is NO_DEFAULT
-                    and self._box_config['default_box']
+            if default is NO_DEFAULT:
+                if (
+                    self._box_config['default_box']
                     and self._box_config['default_box_none_transform']):
-                return self.__get_default(key)
+
+                    return self.__get_default(key)
+                else:
+                    return None
             if isinstance(default, dict) and not isinstance(default, Box):
                 return Box(default)
             if isinstance(default, list) and not isinstance(default, box.BoxList):

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -608,6 +608,7 @@ class TestBox:
     def test_get(self):
         bx = Box()
         bx["c"] = {}
+        assert bx.get("a") is None
         assert isinstance(bx.get("c"), Box)
         assert isinstance(bx.get("b", {}), Box)
         assert "a" in bx.get("a", Box(a=1, conversion_box=False))
@@ -617,6 +618,7 @@ class TestBox:
         bx = Box(default_box=True)
         assert bx.get('test', 4) == 4
         assert isinstance(bx.get('a'), Box)
+        assert bx.get('test', None) is None
 
     def test_inheritance_copy(self):
 


### PR DESCRIPTION
In #107 I fixed calling `.get(key, None)` so it worked for DefaultBoxes, but neglected to account for the case where Box is a non-DefaultBox.

In the current release of Box, `Box().get('x')` returns `object()`. This PR fixes it so `Box().get('x')` is `None`, as expected. (and adds tests)