### PR TITLE
Version 4.1.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,7 +12,6 @@ exclude_lines =
     raise err
     except ImportError
     yaml = none
-    if item == '__box_config'
     raise BoxError\('_box_config key must exist
     raise err
     if 'box_class' in self.__dict__:
@@ -20,5 +19,5 @@ exclude_lines =
     except OSError
     raise BoxError\(f'{filename}
     item._box_config['__box_heritage'] = \(\)
-    except AttributeError as err
-    raise BoxKeyError(err)
+    raise BoxKeyError\(err
+

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ ENV/
 .idea/
 .pypirc
 release.bat
+coverage/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,3 +58,4 @@ Suggestions and bug reporting:
 - Marcelo Huerta (richieadler)
 - Wenbo Zhao (zhaowb)
 - Yordan Ivanov (iordanivanov)
+- Lei (NEOOOOOOOOOO)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,3 +56,5 @@ Suggestions and bug reporting:
 - (iordanivanov)
 - Steven McGrath (SteveMcGrath)
 - Marcelo Huerta (richieadler)
+- Wenbo Zhao (zhaowb)
+- Yordan Ivanov (iordanivanov)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 4.0.5
+-------------
+
+* Changing to allow for `PyYAML` if it already installed vs `ruamel.yaml` (thanks to wim glenn)
+
 Version 4.0.4
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 4.1.0
 -------------
 
 * Adding support for list traversal with `box_dots` (thanks to Lei)
+* Adding `BoxWarning` class to allow for the clean suppression of warnings
 * Fixing default_box_attr to accept items that evaluate to `None` (thanks to Wenbo Zhao and Yordan Ivanov)
 * Changing default_box to set objects in box on lookup
 * Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)
@@ -46,6 +47,7 @@ Version 4.0.0
 * Changing how `safe_attr` handles unsafe characters
 * Changing all exceptions to be bases of BoxError so can always be caught with that base exception
 * Changing delete to also access converted keys (thanks to iordanivanov)
+* Changing from `PyYAML` to `ruamel.yaml` as default yaml import, aka yaml version default is 1.2 instead of 1.1
 * Removing `ordered_box` as Python 3.6+ is ordered by default
 * Removing `BoxObject` in favor of it being another module
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 Version 4.1.0
 -------------
 
+* Adding support for list traversal with `box_dots` (thanks to Lei)
 * Fixing default_box_attr to accept items that evaluate to `None` (thanks to Wenbo Zhao and Yordan Ivanov)
 * Changing default_box to set objects in box on lookup
 * Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changelog
 =========
 
-Version 4.0.5
+Version 4.1.0
 -------------
 
-* Changing to allow for `PyYAML` if it already installed vs `ruamel.yaml` (thanks to wim glenn)
+* Fixing default_box_attr to accept items that evaluate to `None` (thanks to Wenbo Zhao and Yordan Ivanov)
+* Changing default_box to set objects in box on lookup
+* Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)
 
 Version 4.0.4
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Version 4.1.0
 * Changing `camel_killer` to convert items on insert, which will change the keys when converted back to dict unlike before
 * Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)
 * Removing official support for `pypy` as it's pickling behavior is not the same as CPython
+* Removing internal __box_heritage as it was no longer needed due to behavior update
 
 Version 4.0.4
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 4.1.0
 * Fixing `BoxList` to properly send internal box options down into new lists
 * Changing default_box to set objects in box on lookup
 * Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)
+* Removing official support for `pypy` as it's pickling behavior is not the same as CPython
 
 Version 4.0.4
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,9 @@ Version 4.1.0
 * Adding `BoxWarning` class to allow for the clean suppression of warnings
 * Fixing default_box_attr to accept items that evaluate to `None` (thanks to Wenbo Zhao and Yordan Ivanov)
 * Fixing `BoxList` to properly send internal box options down into new lists
+* Fixing issues with conversion and camel killer boxes not being set properly on insert
 * Changing default_box to set objects in box on lookup
+* Changing `camel_killer` to convert items on insert, which will change the keys when converted back to dict unlike before
 * Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)
 * Removing official support for `pypy` as it's pickling behavior is not the same as CPython
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 4.1.0
 * Adding support for list traversal with `box_dots` (thanks to Lei)
 * Adding `BoxWarning` class to allow for the clean suppression of warnings
 * Fixing default_box_attr to accept items that evaluate to `None` (thanks to Wenbo Zhao and Yordan Ivanov)
+* Fixing `BoxList` to properly send internal box options down into new lists
 * Changing default_box to set objects in box on lookup
 * Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2019 Chris Griffith
+Copyright (c) 2017-2020 Chris Griffith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,10 @@ It's boxes all the way down. At least, when you specify `default_box=True` it ca
       empty_box.a.b.c.d.e.f.g
       # <Box: {}>
 
+      # BOX 4.1 change, on lookup the sub boxes are created
+      print(empty_box)
+      # <Box: {'a': {'b': {'c': {'d': {'e': {'f': {'g': {}}}}}}}}>
+
       empty_box.a.b.c.d.e.f.g = "h"
       empty_box
       # <Box: {'a': {'b': {'c': {'d': {'e': {'f': {'g': 'h'}}}}}}}>
@@ -264,6 +268,9 @@ Unless you want it to be something else.
 `default_box_attr` will first check if it is callable, and will call the object
 if it is, otherwise it will see if has the `copy` attribute and will call that,
 lastly, will just use the provided item as is.
+
+4.1 Update: Previous versions had an error when something that evaluated to None would
+also return a box, such as an empty string or empty list. This behavior has been fixed.
 
 Camel Killer Box
 ----------------
@@ -350,6 +357,13 @@ Be aware, if those sub boxes didn't exist as planned, a new key with that value 
 
     # {'incoming.new.source 1.$$$': 'test'}
 
+4.1 Update: Support for traversing box lists as well!
+
+.. code:: python
+
+        my_box = Box({'data': [ {'rabbit': 'hole'} ] }, box_dots=True)
+        print(data.data[0].rabbit)
+        # hole
 
 BoxList
 =======

--- a/README.rst
+++ b/README.rst
@@ -365,6 +365,8 @@ Be aware, if those sub boxes didn't exist as planned, a new key with that value 
         print(data.data[0].rabbit)
         # hole
 
+This does only work for keys that are already strings as of version 4.1.
+
 BoxList
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -510,7 +510,7 @@ to separate the different objects into their own files and test files.
 License
 =======
 
-MIT License, Copyright (c) 2017-2019 Chris Griffith. See LICENSE file.
+MIT License, Copyright (c) 2017-2020 Chris Griffith. See LICENSE file.
 
 
 .. |BoxImage| image:: https://raw.githubusercontent.com/cdgriffith/Box/master/box_logo.png

--- a/box/__init__.py
+++ b/box/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 __author__ = 'Chris Griffith'
-__version__ = '4.0.5'
+__version__ = '4.1.0'
 
 from box.box import Box
 from box.box_list import BoxList

--- a/box/__init__.py
+++ b/box/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 __author__ = 'Chris Griffith'
-__version__ = '4.0.4'
+__version__ = '4.0.5'
 
 from box.box import Box
 from box.box_list import BoxList

--- a/box/box.py
+++ b/box/box.py
@@ -132,6 +132,15 @@ def _conversion_checks(item, keys, box_config, check_only=False, pre_check=False
             return k
 
 
+def _parse_box_dots(item):
+    for idx, char in enumerate(item):
+        if char == '[':
+            return item[:idx], item[idx:]
+        elif char == '.':
+            return item[:idx], item[idx + 1:]
+    raise BoxError('Could not split box dots properly')
+
+
 def _get_box_config(heritage):
     return {
         # Internal use only
@@ -325,15 +334,7 @@ class Box(dict):
             if item == '_box_config':
                 raise BoxKeyError('_box_config should only exist as an attribute and is never defaulted') from None
             if self._box_config['box_dots'] and isinstance(item, str) and ('.' in item or '[' in item):
-                for idx, char in enumerate(item):
-                    if char == '[':
-                        first_item, children = item[:idx], item[idx:]
-                        break
-                    elif char == '.':
-                        first_item, children = item[:idx], item[idx + 1:]
-                        break
-                else:
-                    raise BoxError('Could not split box dots properly')
+                first_item, children = _parse_box_dots(item)
                 if first_item in self.keys():
                     if hasattr(self[first_item], '__getitem__'):
                         return self[first_item][children]
@@ -451,15 +452,7 @@ class Box(dict):
             _conversion_checks(key, self.keys(), self._box_config,
                                check_only=True, pre_check=True)
         if self._box_config['box_dots'] and isinstance(key, str) and '.' in key:
-            for idx, char in enumerate(key):
-                if char == '[':
-                    first_item, children = key[:idx], key[idx:]
-                    break
-                elif char == '.':
-                    first_item, children = key[:idx], key[idx + 1:]
-                    break
-            else:
-                raise BoxError('Could not split box dots properly')
+            first_item, children = _parse_box_dots(key)
             if first_item in self.keys():
                 if hasattr(self[first_item], '__setitem__'):
                     return self[first_item].__setitem__(children, value)

--- a/box/box.py
+++ b/box/box.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
-# Copyright (c) 2017-2019 - Chris Griffith - MIT License
+# Copyright (c) 2017-2020 - Chris Griffith - MIT License
 """
 Improved dictionary access through dot notation with additional tools.
 """
@@ -334,12 +334,7 @@ class Box(dict):
                         break
                 else:
                     raise BoxError('Could not split box dots properly')
-                # list_obj = _list_pos_re.search(first_item)
-                # if list_obj and first_item.endswith(str(list_obj.group())):
-                #     first_item = first_item[:-len(str(list_obj.group()))]
                 if first_item in self.keys():
-                    # if list_obj:
-                    #     return self[first_item][int(list_obj.groups()[0])][children]
                     if hasattr(self[first_item], '__getitem__'):
                         return self[first_item][children]
             if self._box_config['default_box'] and not _ignore_default:
@@ -447,7 +442,6 @@ class Box(dict):
         else:
             if item == '_box_config':
                 return value
-            # return self.__convert_and_store(item, value)
         return value
 
     def __setitem__(self, key, value):

--- a/box/box.py
+++ b/box/box.py
@@ -15,7 +15,7 @@ from typing import Any, Union, Tuple, List, Dict
 from pathlib import Path
 
 import box
-from box.exceptions import BoxError, BoxKeyError, BoxTypeError, BoxValueError
+from box.exceptions import BoxError, BoxKeyError, BoxTypeError, BoxValueError, BoxWarning
 from box.converters import (_to_json, _from_json, _from_toml, _to_toml, _from_yaml, _to_yaml, BOX_PARAMETERS)
 
 __all__ = ['Box']
@@ -27,6 +27,7 @@ _list_pos_re = re.compile(r'\[(\d+)\]')
 # a sentinel object for indicating no default, in order to allow users
 # to pass `None` as a valid default value
 NO_DEFAULT = object()
+
 
 
 def _safe_attr(attr, camel_killer=False, replacement_char='x'):
@@ -119,7 +120,7 @@ def _conversion_checks(item, keys, box_config, check_only=False, pre_check=False
                     dups.add(f'{x[0]}({x[1]})')
                 seen.add(x[1])
             if box_config['box_duplicates'].startswith('warn'):
-                warnings.warn(f'Duplicate conversion attributes exist: {dups}')
+                warnings.warn(f'Duplicate conversion attributes exist: {dups}', BoxWarning)
             else:
                 raise BoxError(f'Duplicate conversion attributes exist: {dups}')
     if check_only:

--- a/box/box.py
+++ b/box/box.py
@@ -263,8 +263,7 @@ class Box(dict):
 
     def __dir__(self):
         allowed = string.ascii_letters + string.digits + '_'
-        kill_camel = self._box_config['camel_killer_box']
-        items = set(self._protected_keys)
+        items = set(super(Box, self).__dir__())
         # Only show items accessible by dot notation
         for key in self.keys():
             key = str(key)
@@ -278,14 +277,9 @@ class Box(dict):
         for key in self.keys():
             if key not in items:
                 if self._box_config['conversion_box']:
-                    key = _safe_attr(key, camel_killer=kill_camel, replacement_char=self._box_config['box_safe_prefix'])
+                    key = _safe_attr(key, replacement_char=self._box_config['box_safe_prefix'])
                     if key:
                         items.add(key)
-            if kill_camel:
-                snake_key = _camel_killer(key)
-                if snake_key:
-                    items.remove(key)
-                    items.add(snake_key)
 
         return list(items)
 

--- a/box/box.py
+++ b/box/box.py
@@ -332,6 +332,10 @@ class Box(dict):
                 if first_item in self.keys():
                     if hasattr(self[first_item], '__getitem__'):
                         return self[first_item][children]
+            if self._box_config['conversion_box'] and item:
+                k = _conversion_checks(item, self.keys(), self._box_config)
+                if k:
+                    return self.__getitem__(k)
             if self._box_config['camel_killer_box'] and isinstance(item, str):
                 converted = _camel_killer(item)
                 if converted in self.keys():
@@ -424,15 +428,6 @@ class Box(dict):
                 raise BoxKeyError(item) from None
             if item == '_box_config':
                 raise BoxError('_box_config key must exist') from None
-            kill_camel = self._box_config['camel_killer_box']
-            if self._box_config['conversion_box'] and item:
-                k = _conversion_checks(item, self.keys(), self._box_config)
-                if k:
-                    return self.__getitem__(k)
-            if kill_camel:
-                for k in self.keys():
-                    if item == _camel_killer(k):
-                        return self.__getitem__(k)
             if self._box_config['default_box']:
                 return self.__get_default(item)
             raise BoxKeyError(str(err)) from None
@@ -454,12 +449,7 @@ class Box(dict):
             if self._box_config['conversion_box']:
                 key = _conversion_checks(key, self.keys(), self._box_config) or key
             if self._box_config['camel_killer_box'] and isinstance(key, str):
-                for each_key in self:
-                    if _camel_killer(key) == each_key:
-                        key = each_key
-                        break
-                else:
-                    key = _camel_killer(key)
+                key = _camel_killer(key)
         super(Box, self).__setitem__(key, value)
         self.__convert_and_store(key, value)
         self.__create_lineage()

--- a/box/box.py
+++ b/box/box.py
@@ -461,7 +461,7 @@ class Box(dict):
                 key = _conversion_checks(key, self.keys(), self._box_config) or key
             if self._box_config['camel_killer_box'] and isinstance(key, str):
                 for each_key in self:
-                    if key == _camel_killer(each_key):
+                    if _camel_killer(key) == each_key:
                         key = each_key
                         break
                 else:
@@ -489,17 +489,13 @@ class Box(dict):
                 return self[first_item].__delitem__(children)
         if key not in self.keys() and (self._box_config['conversion_box'] or self._box_config['camel_killer_box']):
             if self._box_config['conversion_box']:
-                k = _conversion_checks(key, self.keys(), self._box_config)
-                super(Box, self).__delitem__(key if not k else k)
-            elif self._box_config['camel_killer_box']:
+                key = _conversion_checks(key, self.keys(), self._box_config) or key
+            if self._box_config['camel_killer_box'] and isinstance(key, str):
                 for each_key in self:
-                    if key == _camel_killer(each_key):
-                        super(Box, self).__delitem__(each_key)
+                    if _camel_killer(key) == each_key:
+                        key = each_key
                         break
-                else:
-                    raise BoxKeyError(f'Cannot find {key} to delete')
-        else:
-            super(Box, self).__delitem__(key)
+        super(Box, self).__delitem__(key)
 
     def __delattr__(self, item):
         if self._box_config['frozen_box']:
@@ -508,7 +504,7 @@ class Box(dict):
             raise BoxError('"_box_config" is protected')
         if item in self._protected_keys:
             raise BoxKeyError(f'Key name "{item}" is protected')
-        del self[item]
+        self.__delitem__(item)
 
     def pop(self, key, *args):
         if args:

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
+#
+# Copyright (c) 2017-2020 - Chris Griffith - MIT License
 from typing import Iterable
 import re
 import copy
@@ -36,14 +38,10 @@ class BoxList(list):
     def __getitem__(self, item):
         if self.box_options.get('box_dots') and isinstance(item, str) and item.startswith('['):
             list_pos = _list_pos_re.search(item)
-            sel = list_pos.groups()[0]
-            value = super(BoxList, self).__getitem__(int(sel))
+            value = super(BoxList, self).__getitem__(int(list_pos.groups()[0]))
             if len(list_pos.group()) == len(item):
                 return value
-            key = item[len(list_pos.group()):].lstrip('.')
-            if not key:
-                return value
-            return value.__getitem__(key)
+            return value.__getitem__(item[len(list_pos.group()):].lstrip('.'))
         return super(BoxList, self).__getitem__(item)
 
     def __delitem__(self, key):
@@ -56,13 +54,10 @@ class BoxList(list):
             raise BoxError('BoxList is frozen')
         if self.box_options.get('box_dots') and isinstance(key, str) and key.startswith('['):
             list_pos = _list_pos_re.search(key)
-            sel = list_pos.groups()[0]
+            pos = int(list_pos.groups()[0])
             if len(list_pos.group()) == len(key):
-                return super(BoxList, self).__setitem__(int(sel), value)
-            next_key = key[len(list_pos.group()):].lstrip('.')
-            if not next_key:
-                return super(BoxList, self).__setitem__(int(sel), value)
-            return super(BoxList, self).__getitem__(int(sel)).__setitem__(next_key, value)
+                return super(BoxList, self).__setitem__(pos, value)
+            return super(BoxList, self).__getitem__(pos).__setitem__(key[len(list_pos.group()):].lstrip('.'), value)
         super(BoxList, self).__setitem__(key, value)
 
     def _is_intact_type(self, obj):

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -102,9 +102,7 @@ class BoxList(list):
         return str(self.to_list())
 
     def __copy__(self):
-        return BoxList((x for x in self),
-                       self.box_class,
-                       **self.box_options)
+        return BoxList((x for x in self), self.box_class, **self.box_options)
 
     def __deepcopy__(self, memo=None):
         out = self.__class__()

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 from typing import Iterable
-
+import re
 import copy
+
 
 from box.converters import (_to_yaml, _from_yaml, _to_json, _from_json,
                             _to_toml, _from_toml, _to_csv, _from_csv, BOX_PARAMETERS)
 from box.exceptions import BoxError, BoxTypeError, BoxKeyError
 import box
+
+_list_pos_re = re.compile(r'\[(\d+)\]')
 
 
 class BoxList(list):
@@ -30,6 +33,19 @@ class BoxList(list):
             for method in ['append', 'extend', 'insert', 'pop', 'remove', 'reverse', 'sort']:
                 self.__setattr__(method, frozen)
 
+    def __getitem__(self, item):
+        if self.box_options.get('box_dots') and isinstance(item, str) and item.startswith('['):
+            list_pos = _list_pos_re.search(item)
+            sel = list_pos.groups()[0]
+            value = super(BoxList, self).__getitem__(int(sel))
+            if len(list_pos.group()) == len(item):
+                return value
+            key = item[len(list_pos.group()):].lstrip('.')
+            if not key:
+                return value
+            return value.__getitem__(key)
+        return super(BoxList, self).__getitem__(item)
+
     def __delitem__(self, key):
         if self.box_options.get('frozen_box'):
             raise BoxError('BoxList is frozen')
@@ -38,6 +54,15 @@ class BoxList(list):
     def __setitem__(self, key, value):
         if self.box_options.get('frozen_box'):
             raise BoxError('BoxList is frozen')
+        if self.box_options.get('box_dots') and isinstance(key, str) and key.startswith('['):
+            list_pos = _list_pos_re.search(key)
+            sel = list_pos.groups()[0]
+            if len(list_pos.group()) == len(key):
+                return super(BoxList, self).__setitem__(int(sel), value)
+            next_key = key[len(list_pos.group()):].lstrip('.')
+            if not next_key:
+                return super(BoxList, self).__setitem__(int(sel), value)
+            return super(BoxList, self).__getitem__(int(sel)).__setitem__(next_key, value)
         super(BoxList, self).__setitem__(key, value)
 
     def _is_intact_type(self, obj):
@@ -58,7 +83,7 @@ class BoxList(list):
                     raise BoxKeyError(err)
         elif isinstance(p_object, list) and not self._is_intact_type(p_object):
             try:
-                p_object = (self if id(p_object) == self.box_org_ref else BoxList(p_object))
+                p_object = (self if id(p_object) == self.box_org_ref else BoxList(p_object, **self.box_options))
             except AttributeError as err:
                 if 'box_org_ref' in self.__dict__:
                     raise BoxKeyError(err)

--- a/box/config_box.py
+++ b/box/config_box.py
@@ -23,8 +23,10 @@ class ConfigBox(Box):
                                  'from_json', 'from_yaml']
 
     def __getattr__(self, item):
-        """Config file keys are stored in lower case, be a little more
-        loosey goosey"""
+        """
+        Config file keys are stored in lower case, be a little more
+        loosey goosey
+        """
         try:
             return super(ConfigBox, self).__getattr__(item)
         except AttributeError:
@@ -36,7 +38,8 @@ class ConfigBox(Box):
                                                    'getfloat', 'getint']
 
     def bool(self, item, default=None):
-        """ Return value of key as a boolean
+        """
+        Return value of key as a boolean
 
         :param item: key of value to transform
         :param default: value to return if item does not exist
@@ -59,7 +62,8 @@ class ConfigBox(Box):
         return True if item else False
 
     def int(self, item, default=None):
-        """ Return value of key as an int
+        """
+        Return value of key as an int
 
         :param item: key of value to transform
         :param default: value to return if item does not exist
@@ -74,7 +78,8 @@ class ConfigBox(Box):
         return int(item)
 
     def float(self, item, default=None):
-        """ Return value of key as a float
+        """
+        Return value of key as a float
 
         :param item: key of value to transform
         :param default: value to return if item does not exist
@@ -89,7 +94,8 @@ class ConfigBox(Box):
         return float(item)
 
     def list(self, item, default=None, spliter=",", strip=True, mod=None):
-        """ Return value of key as a list
+        """
+        Return value of key as a list
 
         :param item: key of value to transform
         :param mod: function to map against list

--- a/box/converters.py
+++ b/box/converters.py
@@ -8,7 +8,10 @@ import csv
 import json
 from pathlib import Path
 
-import ruamel.yaml as yaml
+try:
+    import ruamel.yaml as yaml
+except ImportError:
+    import yaml
 import toml
 
 from box.exceptions import BoxError

--- a/box/converters.py
+++ b/box/converters.py
@@ -7,11 +7,13 @@ import sys
 import csv
 import json
 from pathlib import Path
+import warnings
 
 try:
     import ruamel.yaml as yaml
 except ImportError:
     import yaml
+    warnings.warn("ruamel.yaml was not detected, using PyYAML instead")
 import toml
 
 from box.exceptions import BoxError

--- a/box/converters.py
+++ b/box/converters.py
@@ -9,14 +9,15 @@ import json
 from pathlib import Path
 import warnings
 
+from box.exceptions import BoxError, BoxWarning
+
 try:
     import ruamel.yaml as yaml
 except ImportError:
     import yaml
-    warnings.warn("ruamel.yaml was not detected, using PyYAML instead")
+    warnings.warn("ruamel.yaml was not detected, using PyYAML instead, which may not support YAML 1.2", BoxWarning)
 import toml
 
-from box.exceptions import BoxError
 
 BOX_PARAMETERS = ('default_box', 'default_box_attr', 'conversion_box',
                   'frozen_box', 'camel_killer_box',

--- a/box/exceptions.py
+++ b/box/exceptions.py
@@ -16,3 +16,7 @@ class BoxTypeError(BoxError, TypeError):
 
 class BoxValueError(BoxError, ValueError):
     """Issue doing something with that value"""
+
+
+class BoxWarning(UserWarning):
+    """Here be dragons"""

--- a/box/from_file.py
+++ b/box/from_file.py
@@ -5,7 +5,10 @@ from typing import Union
 from json import JSONDecodeError
 
 from toml import TomlDecodeError
-from ruamel.yaml import YAMLError
+try:
+    from ruamel.yaml import YAMLError
+except ImportError:
+    from yaml import YAMLError
 
 from box.exceptions import BoxError
 from box.box import Box

--- a/box/shorthand_box.py
+++ b/box/shorthand_box.py
@@ -9,8 +9,7 @@ class SBox(Box):
     ShorthandBox (SBox) allows for
     property access of `dict` `json` and `yaml`
     """
-    _protected_keys = dir({}) + ['to_dict', 'to_json', 'to_yaml',
-                                 'json', 'yaml', 'from_yaml', 'from_json',
+    _protected_keys = dir({}) + ['to_dict', 'to_json', 'to_yaml', 'json', 'yaml', 'from_yaml', 'from_json',
                                  'dict', 'toml', 'from_toml', 'to_toml']
 
     @property

--- a/docs/4.x_changes.rst
+++ b/docs/4.x_changes.rst
@@ -94,7 +94,14 @@ Camel Killer Box now changes keys on insertion
 There was a bug in the 4.0 code that meant camel killer was not working at all under normal conditions due
 to the change of how the box is instantiated.
 
+.. code:: python
 
+        from box import Box
+
+        my_box = Box({'CamelCase': 'Item'}, camel_killer_box=True)
+        assert my_box.camel_case == 'Item'
+        print(my_box.to_dict())
+        # {'camel_case': 'Item'}
 
 
 Conversion keys are now a bit smarter with how they are handled

--- a/docs/4.x_changes.rst
+++ b/docs/4.x_changes.rst
@@ -104,6 +104,36 @@ Keys with safety underscores used to be treated internally as if the underscores
 
 Those issues have been (hopefully) overcome and now will have the expected  `<Box: {'_out': 'preserved', 'out': 'updated'}>`
 
+YAML 1.2 default instead of 1.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ruamel.yaml is now an install requirement and new default instead of PyYAML.
+By design ruamel.yaml uses the newer YAML v1.2 (which PyYAML does not yet support as of Jan 2020).
+
+To use the older version of 1.1, make sure to specify the version while using the from_yaml methods.
+
+.. code:: python
+
+    from box import Box
+    Box.from_yaml("fire_ze_missiles: no")
+    <Box: {'fire_ze_missiles': 'no'}>
+
+    Box.from_yaml("fire_ze_missiles: no", version='1.1')
+    <Box: {'fire_ze_missiles': False}>
+
+You can read more about the differences `here <https://yaml.readthedocs.io/en/latest/pyyaml.html#differences-with-pyyaml>`_
+
+To use PyYAML instead of ruamel.yaml you must install box without dependencies (such as `--no-deps` with `pip`)
+
+If you do chose to stick with PyYaML, you can suppress the warning on just box's import:
+
+.. code:: python
+
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from box import Box
+
 
 Additional changes
 ~~~~~~~~~~~~~~~~~~
@@ -126,7 +156,7 @@ As dictionaries are ordered by default in Python 3.6+ there is no point to conti
 Removing `BoxObject`
 ~~~~~~~~~~~~~~~~~~~~
 
-As BoxObject was not cross platform compatible and had some [issues](https://github.com/GrahamDumpleton/wrapt/issues/132) it has been removed. 
+As BoxObject was not cross platform compatible and had some `issues <https://github.com/GrahamDumpleton/wrapt/issues/132>`_ it has been removed.
 
 Removing `box_it_up`
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/4.x_changes.rst
+++ b/docs/4.x_changes.rst
@@ -88,6 +88,14 @@ Merge update takes existing sub dictionaries into consideration
     repr(box_one)
     "<Box: {'inside_dict': {'data': 5, 'folly': True}}>"
 
+Camel Killer Box now changes keys on insertion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There was a bug in the 4.0 code that meant camel killer was not working at all under normal conditions due
+to the change of how the box is instantiated.
+
+
+
 
 Conversion keys are now a bit smarter with how they are handled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/4.x_changes.rst
+++ b/docs/4.x_changes.rst
@@ -39,6 +39,9 @@ Enabled with `box_dots=True`.
 
 This only works with keys that are string to begin with, as we don't do any automatic conversion behind the scene.
 
+4.1 Update: This now also supports list traversal, like `my_box['my_key[0][0]']`
+
+
 Support for adding two Boxes together
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Box'
-copyright = '2017-2019, Chris Griffith'
+copyright = '2017-2020, Chris Griffith'
 author = 'Chris Griffith'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
-pytest>=5.3.2
-coverage>=5.0.1
+pytest>=5.3.5
+coverage>=5.0.3
 pytest-cov>=2.8.1
 reusables>=0.9.5
-wheel>=0.33.6
+wheel>=0.34.2

--- a/setup.py
+++ b/setup.py
@@ -18,28 +18,13 @@ attrs = dict(re.findall(r"__([a-z]+)__ *= *['\"](.+)['\"]", init_content))
 with open("README.rst", "r") as readme_file:
     long_description = readme_file.read()
 
-
-install_requires = ['toml']
-# If someone is already using PyYAML, default to that instead of requiring ruamel.yaml
-try:
-    import ruamel.yaml as yaml
-except ImportError:
-    try:
-        import yaml
-    except ImportError:
-        install_requires.append('ruamel.yaml')
-    else:
-        install_requires.append('PyYAML')
-else:
-    install_requires.append('ruamel.yaml')
-
 setup(
     name='python-box',
     version=attrs['version'],
     url='https://github.com/cdgriffith/Box',
     license='MIT',
     author=attrs['author'],
-    install_requires=install_requires,
+    install_requires=['toml', 'ruamel.yaml'],
     author_email='chris@cdgriffith.com',
     description='Advanced Python dictionaries with dot notation access',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,28 @@ attrs = dict(re.findall(r"__([a-z]+)__ *= *['\"](.+)['\"]", init_content))
 with open("README.rst", "r") as readme_file:
     long_description = readme_file.read()
 
+
+install_requires = ['toml']
+# If someone is already using PyYAML, default to that instead of requiring ruamel.yaml
+try:
+    import ruamel.yaml as yaml
+except ImportError:
+    try:
+        import yaml
+    except ImportError:
+        install_requires.append('ruamel.yaml')
+    else:
+        install_requires.append('PyYAML')
+else:
+    install_requires.append('ruamel.yaml')
+
 setup(
     name='python-box',
     version=attrs['version'],
     url='https://github.com/cdgriffith/Box',
     license='MIT',
     author=attrs['author'],
-    install_requires=['toml', 'ruamel.yaml'],
+    install_requires=install_requires,
     author_email='chris@cdgriffith.com',
     description='Advanced Python dictionaries with dot notation access',
     long_description=long_description,
@@ -41,7 +56,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
         'Development Status :: 5 - Production/Stable',
         'Natural Language :: English',
         'Intended Audience :: Developers',

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -63,6 +63,12 @@ class TestBox:
         assert bx1.big_camel == 4
         assert bx1.dead_camel == 3
 
+        del bx1.DeadCamel
+        assert 'dead_camel' not in bx1
+        del bx1['big_camel']
+        assert 'big_camel' not in bx1
+        assert len(bx1.keys()) == 0
+
     def test_recursive_tuples(self):
         out = box._recursive_tuples(({'test': 'a'},
                                      ({'second': 'b'},

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -54,6 +54,7 @@ class TestBox:
         bx['BigCamel'] = 4
         assert bx['big_camel'] == 4
         assert bx.big_camel == 4
+        assert bx.BigCamel == 4
 
         bx1 = Box(camel_killer_box=True, conversion_box=True)
         bx1['BigCamel'] = 4
@@ -62,6 +63,8 @@ class TestBox:
         assert bx1['dead_camel'] == 3
         assert bx1.big_camel == 4
         assert bx1.dead_camel == 3
+        assert bx1.BigCamel == 4
+        assert bx1['BigCamel'] == 4
 
         del bx1.DeadCamel
         assert 'dead_camel' not in bx1

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -219,7 +219,6 @@ class TestBox:
 
     def test_dir(self):
         a = Box(test_dict, camel_killer_box=True)
-        print(a)
         assert 'key1' in dir(a)
         assert 'not$allowed' not in dir(a)
         assert 'key4' in a['key 2']
@@ -402,6 +401,7 @@ class TestBox:
     def test_default_box(self):
         bx = Box(test_dict, default_box=True, default_box_attr={'hi': 'there'})
         assert bx.key_88 == {'hi': 'there'}
+        assert bx['test'] == {'hi': 'there'}
 
         bx2 = Box(test_dict, default_box=True, default_box_attr=Box)
         assert isinstance(bx2.key_77, Box)
@@ -484,11 +484,13 @@ class TestBox:
         bx.camel_case = {'new': 'item'}
         assert bx['CamelCase'] == Box(new='item')
 
+        bx['CamelCase'] = 4
+        assert bx.camel_case == 4
+
         bx2 = Box(extended_test_dict)
         bx2.Key_2 = 4
-        print(bx2)
-        assert bx2["Key 2"] == 4
 
+        assert bx2["Key 2"] == 4
 
     def test_functional_data(self):
         data = Box.from_json(filename=data_json_file,

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -45,6 +45,23 @@ class TestBox:
     def test_camel_killer(self):
         assert box._camel_killer("CamelCase") == "camel_case"
         assert box._camel_killer("Terrible321KeyA") == "terrible321_key_a"
+        bx = Box(camel_killer_box=True, conversion_box=False)
+
+        bx.DeadCamel = 3
+        assert bx['dead_camel'] == 3
+        assert bx.dead_camel == 3
+
+        bx['BigCamel'] = 4
+        assert bx['big_camel'] == 4
+        assert bx.big_camel == 4
+
+        bx1 = Box(camel_killer_box=True, conversion_box=True)
+        bx1['BigCamel'] = 4
+        bx1.DeadCamel = 3
+        assert bx1['big_camel'] == 4
+        assert bx1['dead_camel'] == 3
+        assert bx1.big_camel == 4
+        assert bx1.dead_camel == 3
 
     def test_recursive_tuples(self):
         out = box._recursive_tuples(({'test': 'a'},
@@ -196,9 +213,10 @@ class TestBox:
 
     def test_dir(self):
         a = Box(test_dict, camel_killer_box=True)
+        print(a)
         assert 'key1' in dir(a)
         assert 'not$allowed' not in dir(a)
-        assert 'Key4' in a['Key 2']
+        assert 'key4' in a['key 2']
         for item in ('to_yaml', 'to_dict', 'to_json'):
             assert item in dir(a)
 
@@ -462,7 +480,9 @@ class TestBox:
 
         bx2 = Box(extended_test_dict)
         bx2.Key_2 = 4
+        print(bx2)
         assert bx2["Key 2"] == 4
+
 
     def test_functional_data(self):
         data = Box.from_json(filename=data_json_file,

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -751,15 +751,16 @@ class TestBox:
             bx['_box_config']
 
     def test_pop(self):
-        bx = Box(a=4, c={"d": 3})
+        bx = Box(a=4, c={"d": 3}, sub_box=Box(test=1))
         assert bx.pop('a') == 4
         with pytest.raises(BoxKeyError):
             bx.pop('b')
         assert bx.pop('a', None) is None
         assert bx.pop('a', True) is True
-        assert bx == {'c': {"d": 3}}
         with pytest.raises(BoxError):
             bx.pop(1, 2, 3)
+        bx.pop('sub_box').pop('test')
+        assert bx == {'c': {"d": 3}}
         assert bx.pop('c', True) is not True
 
     def test_pop_items(self):
@@ -810,7 +811,10 @@ class TestBox:
         assert b['movies.Spaceballs.Stars[1].role'] == 'Testing'
         assert b.movies.Spaceballs.Stars[1].role == 'Testing'
         with pytest.raises(BoxError):
-            b['movies[4']
+            b['.']
+        with pytest.raises(BoxError):
+            from box.box import _parse_box_dots
+            _parse_box_dots('-')
 
     def test_unicode(self):
         bx = Box()

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -263,7 +263,7 @@ class TestBox:
 
     def test_auto_attr(self):
         a = Box(test_dict, default_box=True)
-        assert a.a.a.a.a == Box()
+        assert isinstance(a.a.a.a.a, Box)
         a.b.b = 4
         assert a.b.b == 4
 
@@ -384,6 +384,21 @@ class TestBox:
 
         bx3 = Box(default_box=True, default_box_attr=3)
         assert bx3.hello == 3
+
+        bx4 = Box(default_box=True, default_box_attr=None)
+        assert bx4.who_is_there is None
+
+        bx5 = Box(default_box=True, default_box_attr=[])
+        assert isinstance(bx5.empty_list_please, list)
+        assert len(bx5.empty_list_please) == 0
+        bx5.empty_list_please.append(1)
+        assert bx5.empty_list_please[0] == 1
+
+        bx6 = Box(default_box=True, default_box_attr=[])
+        my_list = bx6.get('new_list')
+        my_list.append(5)
+        assert bx6.get('new_list')[0] == 5
+
 
     # Issue#59 https://github.com/cdgriffith/Box/issues/59 "Treat None values as non existing keys for default_box"
     def test_default_box_none_transforms(self):

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -405,6 +405,13 @@ class TestBox:
         bx8 = Box(default_box=True, default_box_attr=0)
         assert bx8.nothing == 0
 
+        # Tests __get_default's `copy` clause
+        s = {1, 2, 3}
+        bx9 = Box(default_box=True, default_box_attr=s)
+        assert isinstance(bx9.test, set)
+        assert bx9.test == s
+        assert id(bx9.test) != id(s)
+
     # Issue#59 https://github.com/cdgriffith/Box/issues/59 "Treat None values as non existing keys for default_box"
     def test_default_box_none_transforms(self):
         bx4 = Box({"noneValue": None, "inner": {"noneInner": None}}, default_box=True, default_box_attr="issue#59")
@@ -774,6 +781,8 @@ class TestBox:
         b['movies.Spaceballs.Stars[1].role'] = 'Testing'
         assert b['movies.Spaceballs.Stars[1].role'] == 'Testing'
         assert b.movies.Spaceballs.Stars[1].role == 'Testing'
+        with pytest.raises(BoxError):
+            b['movies[4']
 
     def test_unicode(self):
         bx = Box()

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -802,19 +802,18 @@ class TestBox:
         b = Box(notThief=1, sortaThief=0, reallyAThief=True, camel_killer_box=True)
         b['$OhNo!'] = 3
         c = Box(notThief=1, sortaThief=0, reallyAThief=True, camel_killer_box=True, conversion_box=False)
-        del (b.not_thief)
-        del (b._oh_no_)
-        del (b.really_a_thief)
+        del b.not_thief
+        del b._oh_no_
+        del b.really_a_thief
         with pytest.raises(KeyError):
-            del (b.really_a_thief)
+            del b.really_a_thief
         with pytest.raises(KeyError):
-            del (b._oh_no_)
+            del b._oh_no_
 
-        del (c.not_thief)
-        del (c.really_a_thief)
-        print(dir(c))
+        del c.not_thief
+        del c.really_a_thief
         with pytest.raises(KeyError):
-            del (c.really_a_thief)
+            del c.really_a_thief
 
     def test_add_boxes(self):
         b = Box(c=1)

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -399,6 +399,11 @@ class TestBox:
         my_list.append(5)
         assert bx6.get('new_list')[0] == 5
 
+        bx7 = Box(default_box=True, default_box_attr=False)
+        assert bx7.nothing is False
+
+        bx8 = Box(default_box=True, default_box_attr=0)
+        assert bx8.nothing == 0
 
     # Issue#59 https://github.com/cdgriffith/Box/issues/59 "Treat None values as non existing keys for default_box"
     def test_default_box_none_transforms(self):
@@ -758,13 +763,17 @@ class TestBox:
         assert bl == [['foo']], bl
 
     def test_dots(self):
-        b = Box(movie_data, box_dots=True)
+        b = Box(movie_data.copy(), box_dots=True)
         assert b['movies.Spaceballs.rating'] == "PG"
         b['movies.Spaceballs.rating'] = 4
         assert b['movies.Spaceballs.rating'] == 4
         del b['movies.Spaceballs.rating']
         with pytest.raises(BoxKeyError):
             b['movies.Spaceballs.rating']
+        assert b['movies.Spaceballs.Stars[1].role'] == 'Barf'
+        b['movies.Spaceballs.Stars[1].role'] = 'Testing'
+        assert b['movies.Spaceballs.Stars[1].role'] == 'Testing'
+        assert b.movies.Spaceballs.Stars[1].role == 'Testing'
 
     def test_unicode(self):
         bx = Box()

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -142,3 +142,25 @@ class TestBoxList:
         file = Path(tmp_dir, 'csv_file.csv')
         with pytest.raises(BoxError):
             data.to_csv(file)
+
+    def test_box_list_dots(self):
+        data = BoxList([
+            {'test': 1},
+            {'bad': 2, 'data': 3},
+            [[[0, -1], [77, 88]], {'inner': 'one', 'lister': [[{'down': 'rabbit'}]]}]
+        ], box_dots=True)
+
+        assert data['[0].test'] == 1
+        assert data['[1].data'] == 3
+        assert data[1].data == 3
+        data['[1].data'] = 'new_data'
+        assert data['[1].data'] == 'new_data'
+        assert data['[2][0][0][1]'] == -1
+        assert data[2][0][0][1] == -1
+        data['[2][0][0][1]'] = 1_000_000
+        assert data['[2][0][0][1]'] == 1_000_000
+        assert data[2][0][0][1] == 1_000_000
+        assert data['[2][1].lister[0][0].down'] == 'rabbit'
+        data['[2][1].lister[0][0].down'] = 'hole'
+        assert data['[2][1].lister[0][0].down'] == 'hole'
+        assert data[2][1].lister[0][0].down == 'hole'

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -96,6 +96,8 @@ class TestBoxList:
     def test_box_list_to_toml(self):
         bl = BoxList([{'item': 1, 'CamelBad': 2}])
         assert toml.loads(bl.to_toml(key_name='test'))['test'][0]['item'] == 1
+        with pytest.raises(BoxError):
+            BoxList.from_toml('[[test]]\nitem = 1\nCamelBad = 2\n\n', key_name="does not exist")
 
     def test_box_list_from_tml(self):
         alist = [{'item': 1}, {'CamelBad': 2}]

--- a/test/test_sbox.py
+++ b/test/test_sbox.py
@@ -14,10 +14,10 @@ class TestSBox:
         pbox = SBox(td, camel_killer_box=True)
         assert isinstance(pbox.inner, SBox)
         assert pbox.inner.camel_case == 'Item'
-        assert json.loads(pbox.json)['inner']['CamelCase'] == 'Item'
+        assert json.loads(pbox.json)['inner']['camel_case'] == 'Item'
         test_item = yaml.load(pbox.yaml, Loader=yaml.SafeLoader)
-        assert test_item['inner']['CamelCase'] == 'Item'
+        assert test_item['inner']['camel_case'] == 'Item'
         assert repr(pbox['inner']).startswith('<ShorthandBox')
         assert not isinstance(pbox.dict, Box)
-        assert pbox.dict['inner']['CamelCase'] == 'Item'
+        assert pbox.dict['inner']['camel_case'] == 'Item'
         assert pbox.toml.startswith('key1 = "value1"')


### PR DESCRIPTION
* Adding support for list traversal with `box_dots` (thanks to Lei)
* Adding `BoxWarning` class to allow for the clean suppression of warnings
* Fixing default_box_attr to accept items that evaluate to `None` (thanks to Wenbo Zhao and Yordan Ivanov)
* Changing default_box to set objects in box on lookup
* Fallback to `PyYAML` if `ruamel.yaml` is not detected (thanks to wim glenn)