### PR TITLE
Speed up crud operations.

### DIFF
--- a/box/box.py
+++ b/box/box.py
@@ -105,8 +105,7 @@ def _conversion_checks(item, safe_keys, box_config, check_only=False, pre_check=
     """
     if box_config['box_duplicates'] != 'ignore':
         safe_item = _safe_attr(item, camel_killer=box_config['camel_killer_box'],
-                                   replacement_char=box_config['box_safe_prefix']
-            )
+                               replacement_char=box_config['box_safe_prefix'])
 
         if safe_item in safe_keys:
             dups = set()
@@ -277,8 +276,8 @@ class Box(dict):
         if key not in self:
             if default is NO_DEFAULT:
                 if (
-                    self._box_config['default_box']
-                    and self._box_config['default_box_none_transform']):
+                        self._box_config['default_box']
+                        and self._box_config['default_box_none_transform']):
 
                     return self.__get_default(key)
                 else:
@@ -514,7 +513,7 @@ class Box(dict):
     def __delattr__(self, item):
         if self._box_config['frozen_box']:
             raise BoxError('Box is frozen')
-        if item  == '_box_config':
+        if item == '_box_config':
             raise BoxError('"_box_config" is protected')
         if item in self._protected_keys:
             raise BoxKeyError(f'Key name "{item}" is protected')


### PR DESCRIPTION
This fixes [#129](https://github.com/cdgriffith/Box/issues/129).

Because of `_conversion_checks` the complexity of a single `__setattr__` is something like O(number_of_keys * key_size). Hence the complexity of merge_update would be O(number_of_keys * number_of_keys * key_size). This comes as a surprise when you expect the complexity to be O(number_of_keys * log(number_of_keys)).

This PR addresses this performance issue by using a dictionary mapping safe keys to old keys.

All the unit tests are passing. I am not familiar enough with Box to know if the use of `__setattr__` and `__setitem__` might lead to an inconsistent state of the Box, or if the unit tests cover this. Eventually, you might consider refactoring the code a bit (this is better done by the author who knows the code well).