### PR TITLE
Fixing #141

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,3 +61,4 @@ Suggestions and bug reporting:
 - Wenbo Zhao (zhaowb)
 - Yordan Ivanov (iordanivanov)
 - Lei (NEOOOOOOOOOO)
+- Pymancer

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@ Changelog
 =========
 
 
+Version 4.2.2
+-------------
+
+* Fixing `default_box` doesn't first look for safe attributes before falling back to default (thanks to Pymancer)
+
 Version 4.2.1
 -------------
 

--- a/box/__init__.py
+++ b/box/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 __author__ = 'Chris Griffith'
-__version__ = '4.2.1'
+__version__ = '4.2.2'
 
 from box.box import Box
 from box.box_list import BoxList

--- a/box/box.py
+++ b/box/box.py
@@ -337,12 +337,12 @@ class Box(dict):
                 raise BoxKeyError(item) from None
             if item == '_box_config':
                 raise BoxError('_box_config key must exist') from None
-            if self._box_config['default_box']:
-                return self.__get_default(item)
             if self._box_config['conversion_box']:
                 safe_key = self._safe_attr(item)
                 if safe_key in self._box_config['__safe_keys']:
                     return self.__getitem__(self._box_config['__safe_keys'][safe_key])
+            if self._box_config['default_box']:
+                return self.__get_default(item)
             raise BoxKeyError(str(err)) from None
         return value
 

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -427,6 +427,12 @@ class TestBox:
         assert bx9.test == s
         assert id(bx9.test) != id(s)
 
+        bx10 = Box({'from': 'here'}, default_box=True)
+        assert bx10.xfrom == 'here'
+        bx10.xfrom = 5
+        assert bx10.xfrom == 5
+        assert bx10 == {'from': 5}
+
     # Issue#59 https://github.com/cdgriffith/Box/issues/59 "Treat None values as non existing keys for default_box"
     def test_default_box_none_transforms(self):
         bx4 = Box({"noneValue": None, "inner": {"noneInner": None}}, default_box=True, default_box_attr="issue#59")


### PR DESCRIPTION
* Fixing `default_box` doesn't first look for safe attributes before falling back to default (thanks to Pymancer)