### PR TITLE
Issue157 bug in box.setdefault

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ Code contributions:
 - (jandelgado)
 - Jonas Irgens Kylling (jkylling)
 - Bruno Rocha (rochacbruno)
+- Noam Graetz (NoamGraetz2)
 
 Suggestions and bug reporting:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fixed bug in box.set_default where value is dictionary (return the internal value and not detached temporary)
+
 Version 5.1.0
 -------------
 

--- a/box/box.py
+++ b/box/box.py
@@ -660,7 +660,7 @@ class Box(dict):
         if isinstance(default, list):
             default = box.BoxList(default, **self.__box_config())
         self[item] = default
-        return default
+        return self[item]
 
     def _safe_attr(self, attr):
         """Convert a key into something that is accessible as an attribute"""

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -289,6 +289,12 @@ class TestBox:
         a.b.b = 4
         assert a.b.b == 4
 
+    def test_set_default_dict(self):
+        a = Box(test_dict)
+        new = a.setdefault("key3", {})
+        new.yy = 8
+        assert a.key3.yy == 8
+
     def test_set_default(self):
         a = Box(test_dict)
 


### PR DESCRIPTION
when using box.setdefault with dict, it returned a 'detached' object that did not reflect changes on the original box
i.e. if using b = a.setdefault('x', {}), updated to 'b' did not reflect to 'a'

simple fix.
added test.

this is my 1st contribution, so if something is missing, please let me know