### PR TITLE
Update requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 coverage>=5.0.4
+msgpack>=1.0
 pytest-cov>=2.8.1
 pytest>=5.4.1
-reusables>=0.9.5
+ruamel.yaml>=0.16
 wheel>=0.34.2


### PR DESCRIPTION
`reusables` seems no longer necessary to run the tests but `msgpack` (https://github.com/cdgriffith/Box/blob/4b66113d193690191d488e45818f80a1f7f85285/test/test_converters.py#L9) and `ramel.yaml` (https://github.com/cdgriffith/Box/blob/4b66113d193690191d488e45818f80a1f7f85285/test/test_converters.py#L11).