### PR TITLE
Support box_recast with functions and other non-classes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Code contributions:
 - Noam Graetz (NoamGraetz2)
 - Fabian Affolter (fabaff)
 - Varun Madiath (vamega)
+- Jacob Hayes (JacobHayes)
 
 Suggestions and bug reporting:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-UNRELEASED
-----------
+Version 5.3.0
+-------------
 
 * Add support for functions to box_recast (thanks to Jacob Hayes)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+* Add support for functions to box_recast (thanks to Jacob Hayes)
+
 Version 5.2.0
 -------------
 

--- a/box/__init__.py
+++ b/box/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 __author__ = "Chris Griffith"
-__version__ = "5.2.0"
+__version__ = "5.3.0"
 
 from box.box import Box
 from box.box_list import BoxList

--- a/box/box.py
+++ b/box/box.py
@@ -411,13 +411,14 @@ class Box(dict):
 
     def __recast(self, item, value):
         if self._box_config["box_recast"] and item in self._box_config["box_recast"]:
+            recast = self._box_config["box_recast"][item]
             try:
-                if issubclass(self._box_config["box_recast"][item], (Box, box.BoxList)):
-                    return self._box_config["box_recast"][item](value, **self.__box_config())
+                if isinstance(recast, type) and issubclass(recast, (Box, box.BoxList)):
+                    return recast(value, **self.__box_config())
                 else:
-                    return self._box_config["box_recast"][item](value)
+                    return recast(value)
             except ValueError:
-                raise BoxValueError(f'Cannot convert {value} to {self._box_config["box_recast"][item]}') from None
+                raise BoxValueError(f'Cannot convert {value} to {recast}') from None
         return value
 
     def __convert_and_store(self, item, value):

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -990,6 +990,15 @@ class TestBox:
         with pytest.raises(ValueError):
             b["sub_box"] = {"id": "bad_id"}
 
+    def test_nontype_recast(self):
+        def cast_id(val) -> int:
+            return int(val)
+
+        b = Box(id="6", box_recast={"id": cast_id})
+        assert isinstance(b.id, int)
+        with pytest.raises(ValueError):
+            b["sub_box"] = {"id": "bad_id"}
+
     def test_box_dots(self):
         b = Box(
             {"my_key": {"does stuff": {"to get to": "where I want"}}, "key.with.list": [[[{"test": "value"}]]]},


### PR DESCRIPTION
`box_recast` doesn't support non-class callables (functions, methods, etc) because the `issubclass` check fails for non-classes. This adds a guard check to only do the subclass check for classes. This allows one to use a validation or parsing function rather than just instantiating a class.