### PR TITLE
Version 5.3.0

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,4 +1,4 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package
@@ -17,11 +17,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine --upgrade
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9.0-rc.1, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v2
@@ -58,11 +58,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-test.txt
-        pip install coveralls
     - name: Test with pytest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pytest --cov=box test/
-        coveralls
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -72,3 +72,6 @@ Suggestions and bug reporting:
 - David Aronchick (aronchick)
 - Alexander Kapustin (dyens)
 - Marcelo Huerta (richieadler)
+- Tim Schwenke (trallnag)
+- Marcos Dione (mdione-cloudian)
+- Varun Madiath (vamega)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Code contributions:
 - Noam Graetz (NoamGraetz2)
 - Fabian Affolter (fabaff)
 - Varun Madiath (vamega)
+- Jacob Hayes (JacobHayes)
 
 Suggestions and bug reporting:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,9 @@ Version 5.3.0
 * Fixing maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
 * Fixing #177 that emtpy yaml files raised errors instead of returning empty objects (thanks to Tim Schwenke)
 * Fixing #171 that `popitems` wasn't first checking if box was frozen (thanks to Varun Madiath)
+* Changing all files to LF line endings
 * Removing duplicate `box_recast` calls (thanks to Jacob Hayes)
+* Removing coveralls code coverage, due to repeated issues with service
 
 Version 5.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changelog
 Version 5.3.0
 -------------
 
-* Add support for functions to box_recast (thanks to Jacob Hayes)
-* Maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
+* Adding support for functions to box_recast (thanks to Jacob Hayes)
+* Adding #181 support for extending or adding new items to list during `merge_update`  (thanks to Marcos Dione)
+* Fixing maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
+* Fixing #177 that emtpy yaml files raised errors instead of returning empty objects (thanks to Tim Schwenke)
+* Fixing #171 that `popitems` wasn't first checking if box was frozen (thanks to Varun Madiath)
 
 Version 5.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Version 5.3.0
 * Fixing maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
 * Fixing #177 that emtpy yaml files raised errors instead of returning empty objects (thanks to Tim Schwenke)
 * Fixing #171 that `popitems` wasn't first checking if box was frozen (thanks to Varun Madiath)
+* Removing duplicate `box_recast` calls (thanks to Jacob Hayes)
 
 Version 5.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 5.3.0
+-------------
+
+* Add support for functions to box_recast (thanks to Jacob Hayes)
+
 Version 5.2.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 5.3.0
 -------------
 
 * Add support for functions to box_recast (thanks to Jacob Hayes)
+* Maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
 
 Version 5.2.0
 -------------

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|BuildStatus| |CoverageStatus| |License|
+|BuildStatus| |License|
 
 |BoxImage|
 
@@ -103,8 +103,6 @@ MIT License, Copyright (c) 2017-2020 Chris Griffith. See LICENSE_ file.
    :target: https://github.com/cdgriffith/Box
 .. |BuildStatus| image:: https://github.com/cdgriffith/Box/workflows/Tests/badge.svg?branch=master
    :target: https://github.com/cdgriffith/Box/actions?query=workflow%3ATests
-.. |CoverageStatus| image:: https://img.shields.io/coveralls/cdgriffith/Box/master.svg?maxAge=2592000
-   :target: https://coveralls.io/r/cdgriffith/Box?branch=master
 .. |License| image:: https://img.shields.io/pypi/l/python-box.svg
    :target: https://pypi.python.org/pypi/python-box/
 

--- a/box/__init__.py
+++ b/box/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 __author__ = "Chris Griffith"
-__version__ = "5.2.0"
+__version__ = "5.3.0"
 
 from box.box import Box
 from box.box_list import BoxList

--- a/box/box.py
+++ b/box/box.py
@@ -502,7 +502,7 @@ class Box(dict):
         return value
 
     def __setitem__(self, key, value):
-        if key != "_box_config" and self._box_config["__created"] and self._box_config["frozen_box"]:
+        if key != "_box_config" and self._box_config["frozen_box"] and self._box_config["__created"]:
             raise BoxError("Box is frozen")
         if self._box_config["box_dots"] and isinstance(key, str) and ("." in key or "[" in key):
             first_item, children = _parse_box_dots(self, key, setting=True)
@@ -524,7 +524,6 @@ class Box(dict):
             raise BoxKeyError(f'Key name "{key}" is protected')
         if key == "_box_config":
             return object.__setattr__(self, key, value)
-        value = self.__recast(key, value)
         safe_key = self._safe_attr(key)
         if safe_key in self._box_config["__safe_keys"]:
             key = self._box_config["__safe_keys"][safe_key]

--- a/box/box.py
+++ b/box/box.py
@@ -411,13 +411,14 @@ class Box(dict):
 
     def __recast(self, item, value):
         if self._box_config["box_recast"] and item in self._box_config["box_recast"]:
+            recast = self._box_config["box_recast"][item]
             try:
-                if issubclass(self._box_config["box_recast"][item], (Box, box.BoxList)):
-                    return self._box_config["box_recast"][item](value, **self.__box_config())
+                if isinstance(recast, type) and issubclass(recast, (Box, box.BoxList)):
+                    return recast(value, **self.__box_config())
                 else:
-                    return self._box_config["box_recast"][item](value)
+                    return recast(value)
             except ValueError:
-                raise BoxValueError(f'Cannot convert {value} to {self._box_config["box_recast"][item]}') from None
+                raise BoxValueError(f'Cannot convert {value} to {recast}') from None
         return value
 
     def __convert_and_store(self, item, value):

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -216,10 +216,10 @@ class BoxList(list):
         :param kwargs: parameters to pass to `Box()` or `json.loads`
         :return: BoxList object from json data
         """
-        bx_args = {}
+        box_args = {}
         for arg in list(kwargs.keys()):
             if arg in BOX_PARAMETERS:
-                bx_args[arg] = kwargs.pop(arg)
+                box_args[arg] = kwargs.pop(arg)
 
         data = _from_json(
             json_string, filename=filename, encoding=encoding, errors=errors, multiline=multiline, **kwargs
@@ -227,7 +227,7 @@ class BoxList(list):
 
         if not isinstance(data, list):
             raise BoxError(f"json data not returned as a list, but rather a {type(data).__name__}")
-        return cls(data, **bx_args)
+        return cls(data, **box_args)
 
     if yaml_available:
 
@@ -277,15 +277,17 @@ class BoxList(list):
             :param kwargs: parameters to pass to `BoxList()` or `yaml.load`
             :return: BoxList object from yaml data
             """
-            bx_args = {}
+            box_args = {}
             for arg in list(kwargs.keys()):
                 if arg in BOX_PARAMETERS:
-                    bx_args[arg] = kwargs.pop(arg)
+                    box_args[arg] = kwargs.pop(arg)
 
             data = _from_yaml(yaml_string=yaml_string, filename=filename, encoding=encoding, errors=errors, **kwargs)
+            if not data:
+                return cls(**box_args)
             if not isinstance(data, list):
                 raise BoxError(f"yaml data not returned as a list but rather a {type(data).__name__}")
-            return cls(data, **bx_args)
+            return cls(data, **box_args)
 
     else:
 
@@ -353,15 +355,15 @@ class BoxList(list):
             :param kwargs: parameters to pass to `Box()`
             :return:
             """
-            bx_args = {}
+            box_args = {}
             for arg in list(kwargs.keys()):
                 if arg in BOX_PARAMETERS:
-                    bx_args[arg] = kwargs.pop(arg)
+                    box_args[arg] = kwargs.pop(arg)
 
             data = _from_toml(toml_string=toml_string, filename=filename, encoding=encoding, errors=errors)
             if key_name not in data:
                 raise BoxError(f"{key_name} was not found.")
-            return cls(data[key_name], **bx_args)
+            return cls(data[key_name], **box_args)
 
     else:
 
@@ -407,15 +409,15 @@ class BoxList(list):
             :param kwargs: parameters to pass to `Box()`
             :return:
             """
-            bx_args = {}
+            box_args = {}
             for arg in list(kwargs.keys()):
                 if arg in BOX_PARAMETERS:
-                    bx_args[arg] = kwargs.pop(arg)
+                    box_args[arg] = kwargs.pop(arg)
 
             data = _from_msgpack(msgpack_bytes=msgpack_bytes, filename=filename, **kwargs)
             if not isinstance(data, list):
                 raise BoxError(f"msgpack data not returned as a list but rather a {type(data).__name__}")
-            return cls(data, **bx_args)
+            return cls(data, **box_args)
 
     else:
 

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1183,3 +1183,22 @@ class TestBox:
         a.b.b = 4
         assert a == {"a.a.a": {"": {"": {}}}, "b.b": 3, "b": {"b": 4}}
         assert a["non.existent.key"] == {}
+
+    def test_merge_list_options(self):
+        a = Box()
+        a.merge_update({"lister": ["a"]})
+        a.merge_update({"lister": ["a", "b", "c"]}, box_merge_lists="extend")
+        assert a.lister == ["a", "a", "b", "c"]
+        a.merge_update({"lister": ["a", "b", "c"]}, box_merge_lists="unique")
+        assert a.lister == ["a", "a", "b", "c"]
+        a.merge_update({"lister": ["a", "d", "b", "c"]}, box_merge_lists="unique")
+        assert a.lister == ["a", "a", "b", "c", "d"]
+        a.merge_update({"key1": {"new": 5}, "Key 2": {"add_key": 6}, "lister": ["a"]})
+        assert a.lister == ["a"]
+
+    def test_box_from_empty_yaml(self):
+        out = Box.from_yaml("---")
+        assert out == Box()
+
+        out2 = BoxList.from_yaml("---")
+        assert out2 == BoxList()

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -991,13 +991,19 @@ class TestBox:
             b["sub_box"] = {"id": "bad_id"}
 
     def test_nontype_recast(self):
+        class CustomError(ValueError):
+            pass
+
         def cast_id(val) -> int:
+            if val == "bad_id":
+                raise CustomError()
             return int(val)
 
         b = Box(id="6", box_recast={"id": cast_id})
         assert isinstance(b.id, int)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exc_info:
             b["sub_box"] = {"id": "bad_id"}
+        assert isinstance(exc_info.value.__cause__, CustomError)
 
     def test_box_dots(self):
         b = Box(

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -990,6 +990,15 @@ class TestBox:
         with pytest.raises(ValueError):
             b["sub_box"] = {"id": "bad_id"}
 
+    def test_nontype_recast(self):
+        def cast_id(val) -> int:
+            return int(val)
+
+        b = Box(id="6", box_recast={"id": cast_id})
+        assert isinstance(b.id, int)
+        with pytest.raises(ValueError):
+            b["sub_box"] = {"id": "bad_id"}
+
     def test_box_dots(self):
         b = Box(
             {"my_key": {"does stuff": {"to get to": "where I want"}}, "key.with.list": [[[{"test": "value"}]]]},


### PR DESCRIPTION
* Adding support for functions to box_recast (thanks to Jacob Hayes)
* Adding #181 support for extending or adding new items to list during `merge_update`  (thanks to Marcos Dione)
* Fixing maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
* Fixing #177 that emtpy yaml files raised errors instead of returning empty objects (thanks to Tim Schwenke)
* Fixing #171 that `popitems` wasn't first checking if box was frozen (thanks to Varun Madiath)

Co-authored-by: Jacob Hayes <jacob.r.hayes@gmail.com>