### PR TITLE
Remove duplicate __recast call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Version 5.3.0
 * Fixing maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
 * Fixing #177 that emtpy yaml files raised errors instead of returning empty objects (thanks to Tim Schwenke)
 * Fixing #171 that `popitems` wasn't first checking if box was frozen (thanks to Varun Madiath)
+* Removing duplicate `box_recast` calls (thanks to Jacob Hayes)
 
 Version 5.2.0
 -------------

--- a/box/box.py
+++ b/box/box.py
@@ -502,7 +502,7 @@ class Box(dict):
         return value
 
     def __setitem__(self, key, value):
-        if key != "_box_config" and self._box_config["__created"] and self._box_config["frozen_box"]:
+        if key != "_box_config" and self._box_config["frozen_box"] and self._box_config["__created"]:
             raise BoxError("Box is frozen")
         if self._box_config["box_dots"] and isinstance(key, str) and ("." in key or "[" in key):
             first_item, children = _parse_box_dots(self, key, setting=True)
@@ -524,7 +524,6 @@ class Box(dict):
             raise BoxKeyError(f'Key name "{key}" is protected')
         if key == "_box_config":
             return object.__setattr__(self, key, value)
-        value = self.__recast(key, value)
         safe_key = self._safe_attr(key)
         if safe_key in self._box_config["__safe_keys"]:
             key = self._box_config["__safe_keys"][safe_key]


### PR DESCRIPTION
__recast was being called twice - once in __setattr__ and again in __setitem__. Since __setattr__ defers to __setitem__, we don't need to call in __setattr__. Also, some of the "is frozen" checks weren't aligned between the two methods (so fixed to make them match).