### PR TITLE
Avoid masking exceptions raised during recast

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 5.3.0
 * Adding support for functions to box_recast (thanks to Jacob Hayes)
 * Adding #181 support for extending or adding new items to list during `merge_update`  (thanks to Marcos Dione)
 * Fixing maintain stacktrace cause for BoxKeyError and BoxValueError (thanks to Jacob Hayes)
+* Fixing masked box_recast exceptions (thanks to Jacob Hayes)
 * Fixing #177 that emtpy yaml files raised errors instead of returning empty objects (thanks to Tim Schwenke)
 * Fixing #171 that `popitems` wasn't first checking if box was frozen (thanks to Varun Madiath)
 

--- a/box/box.py
+++ b/box/box.py
@@ -421,13 +421,10 @@ class Box(dict):
     def __recast(self, item, value):
         if self._box_config["box_recast"] and item in self._box_config["box_recast"]:
             recast = self._box_config["box_recast"][item]
-            try:
-                if isinstance(recast, type) and issubclass(recast, (Box, box.BoxList)):
-                    return recast(value, **self.__box_config())
-                else:
-                    return recast(value)
-            except ValueError as err:
-                raise BoxValueError(f'Cannot convert {value} to {recast}') from _exception_cause(err)
+            if isinstance(recast, type) and issubclass(recast, (Box, box.BoxList)):
+                return recast(value, **self.__box_config())
+            else:
+                return recast(value)
         return value
 
     def __convert_and_store(self, item, value):

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1001,9 +1001,8 @@ class TestBox:
 
         b = Box(id="6", box_recast={"id": cast_id})
         assert isinstance(b.id, int)
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(CustomError) as exc_info:
             b["sub_box"] = {"id": "bad_id"}
-        assert isinstance(exc_info.value.__cause__, CustomError)
 
     def test_box_dots(self):
         b = Box(


### PR DESCRIPTION
Follow up on https://github.com/cdgriffith/Box/issues/179#issuecomment-720900253 - basically allow any recast errors (such as validation messages or helping hints for consumers) to be shown directly.

Resolves #179