### PR TITLE
Support skipping tests requiring the deprecated `toml` package

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,6 +27,7 @@ Code contributions:
 - Jacob Hayes (JacobHayes)
 - Dominic (Yobmod)
 - Ivan Pepelnjak (ipspace)
+- Michał Górny (mgorny)
 
 Suggestions and bug reporting:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 6.1.0
 * Fixing mypy __ior__ type (thanks to Jacob Hayes)
 * Fixing line endings with a pre-commit update
 * Fixing BoxList was using old style of `super` in internal code usage
+* Skipping the tests requiring `toml` if it is not available
 
 Version 6.0.2
 -------------

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1092,6 +1092,7 @@ class TestBox:
             d.keys(dotted=True)
 
     def test_toml(self):
+        pytest.importorskip("toml")
         b = Box.from_toml(filename=Path(test_root, "data", "toml_file.tml"), default_box=True)
         assert b.database.server == "192.168.1.1"
         assert b.clients.hosts == ["alpha", "omega"]

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -11,7 +11,6 @@ from test.common import test_root, tmp_dir
 
 import pytest
 from ruamel.yaml import YAML
-import toml
 
 from box import Box, BoxError, BoxList
 
@@ -100,12 +99,14 @@ class TestBoxList:
             BoxList.from_yaml("a: 2")
 
     def test_box_list_to_toml(self):
+        toml = pytest.importorskip("toml")
         bl = BoxList([{"item": 1, "CamelBad": 2}])
         assert toml.loads(bl.to_toml(key_name="test"))["test"][0]["item"] == 1
         with pytest.raises(BoxError):
             BoxList.from_toml("[[test]]\nitem = 1\nCamelBad = 2\n\n", key_name="does not exist")
 
     def test_box_list_from_tml(self):
+        toml = pytest.importorskip("toml")
         alist = [{"item": 1}, {"CamelBad": 2}]
         toml_list = toml.dumps({"key": alist})
         bl = BoxList.from_toml(toml_string=toml_list, key_name="key", camel_killer_box=True)

--- a/test/test_converters.py
+++ b/test/test_converters.py
@@ -42,10 +42,12 @@ class TestConverters:
         shutil.rmtree(str(tmp_dir), ignore_errors=True)
 
     def test_to_toml(self):
+        pytest.importorskip("toml")
         formatted = _to_toml(movie_data)
         assert formatted.startswith("[movies.Spaceballs]")
 
     def test_to_toml_file(self):
+        pytest.importorskip("toml")
         out_file = Path(tmp_dir, "toml_test.tml")
         assert not out_file.exists()
         _to_toml(movie_data, filename=out_file)
@@ -53,10 +55,12 @@ class TestConverters:
         assert out_file.read_text().startswith("[movies.Spaceballs]")
 
     def test_from_toml(self):
+        pytest.importorskip("toml")
         result = _from_toml(toml_string)
         assert result["movies"]["Spaceballs"]["length"] == 96
 
     def test_from_toml_file(self):
+        pytest.importorskip("toml")
         out_file = Path(tmp_dir, "toml_test.tml")
         assert not out_file.exists()
         out_file.write_text(toml_string)

--- a/test/test_from_file.py
+++ b/test/test_from_file.py
@@ -11,16 +11,19 @@ from box import Box, BoxError, BoxList, box_from_file
 class TestFromFile:
     def test_from_all(self):
         assert isinstance(box_from_file(Path(test_root, "data", "json_file.json")), Box)
-        assert isinstance(box_from_file(Path(test_root, "data", "toml_file.tml")), Box)
         assert isinstance(box_from_file(Path(test_root, "data", "yaml_file.yaml")), Box)
         assert isinstance(box_from_file(Path(test_root, "data", "json_file.json"), file_type="json"), Box)
-        assert isinstance(box_from_file(Path(test_root, "data", "toml_file.tml"), file_type="toml"), Box)
         assert isinstance(box_from_file(Path(test_root, "data", "yaml_file.yaml"), file_type="yaml"), Box)
         assert isinstance(box_from_file(Path(test_root, "data", "json_list.json")), BoxList)
         assert isinstance(box_from_file(Path(test_root, "data", "yaml_list.yaml")), BoxList)
         assert isinstance(box_from_file(Path(test_root, "data", "msgpack_file.msgpack")), Box)
         assert isinstance(box_from_file(Path(test_root, "data", "msgpack_list.msgpack")), BoxList)
         assert isinstance(box_from_file(Path(test_root, "data", "csv_file.csv")), BoxList)
+
+    def test_from_toml(self):
+        pytest.importorskip("toml")
+        assert isinstance(box_from_file(Path(test_root, "data", "toml_file.tml")), Box)
+        assert isinstance(box_from_file(Path(test_root, "data", "toml_file.tml"), file_type="toml"), Box)
 
     def test_bad_file(self):
         with pytest.raises(BoxError):

--- a/test/test_sbox.py
+++ b/test/test_sbox.py
@@ -3,6 +3,8 @@
 import json
 from test.common import test_dict
 
+import pytest
+
 from ruamel.yaml import YAML
 
 from box import Box, SBox
@@ -10,6 +12,7 @@ from box import Box, SBox
 
 class TestSBox:
     def test_property_box(self):
+        pytest.importorskip("toml")
         td = test_dict.copy()
         td["inner"] = {"CamelCase": "Item"}
 


### PR DESCRIPTION
The `toml` package is deprecated and in process of being removed from at least Gentoo and Fedora.  Since the package wishes to preserve support for it, make it possible to run the test suite without it through skipping the relevant tests if `toml` is not available.