### PR TITLE
Add property support for Box

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ Code contributions:
 - Dominic (Yobmod)
 - Ivan Pepelnjak (ipspace)
 - Michał Górny (mgorny)
+- Serge Lu (Serge45)
 
 Suggestions and bug reporting:
 

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1355,3 +1355,33 @@ class TestBox:
         assert "c" not in box2.a.b
 
         assert box2 == Box()
+
+    def test_box_property_support(self):
+        class BoxWithProperty(Box):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            @property
+            def field(self):
+                return self._field
+
+            @field.setter
+            def field(self, value):
+                self._field = value
+
+            @field.deleter
+            def field(self):
+                """
+                This is required to make `del box.field` work properly otherwise a `BoxKeyError` would be thrown.
+                """
+                del self._field
+
+        box = BoxWithProperty()
+        box.field = 5
+
+        assert 'field' not in box
+        assert '_field' in box
+        assert box.field == 5
+        assert box._field == 5
+        del box.field
+        assert not '_field' in box


### PR DESCRIPTION
As requested to issue #211, this PR makes adding property with getter, setter and deleter to Box possible.

The idea is to check if the field is a property (a private function `_get_property_func` was added for this), if so, 
for setter, getter or deleter, box will route to the customized function if exists else the original implementation.