### PR TITLE
Add box_namespace to track nested Box names

### DIFF
--- a/box/box.py
+++ b/box/box.py
@@ -10,8 +10,7 @@ import re
 import warnings
 from keyword import iskeyword
 from os import PathLike
-from typing import Optional, Any, Dict, Generator, List, Tuple, Union, Type
-from typing import Any, Dict, Generator, List, Tuple, Union, Type, Optional
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 try:
     from typing import Callable, Iterable, Mapping
@@ -45,6 +44,8 @@ _list_pos_re = re.compile(r"\[(\d+)\]")
 # a sentinel object for indicating no default, in order to allow users
 # to pass `None` as a valid default value
 NO_DEFAULT = object()
+# a sentinel object for indicating when to skip adding a new namespace, allowing `None` keys
+NO_NAMESPACE = object()
 
 
 def _exception_cause(e):
@@ -479,12 +480,12 @@ class Box(dict):
                 super().__setitem__(item, value)
         return value
 
-    def __box_config(self, extra_namespace: Optional[str] = None) -> Dict:
+    def __box_config(self, extra_namespace: Any = NO_NAMESPACE) -> Dict:
         out = {}
         for k, v in self._box_config.copy().items():
             if not k.startswith("__"):
                 out[k] = v
-        if extra_namespace is not None:
+        if extra_namespace is not NO_NAMESPACE:
             out["box_namespace"] = (*out["box_namespace"], extra_namespace)
         return out
 

--- a/box/box.py
+++ b/box/box.py
@@ -11,6 +11,7 @@ import warnings
 from keyword import iskeyword
 from os import PathLike
 from typing import Optional, Any, Dict, Generator, List, Tuple, Union, Type
+from typing import Any, Dict, Generator, List, Tuple, Union, Type, Optional
 
 try:
     from typing import Callable, Iterable, Mapping
@@ -158,6 +159,7 @@ class Box(dict):
     :param box_recast: cast certain keys to a specified type
     :param box_dots: access nested Boxes by period separated keys in string
     :param box_class: change what type of class sub-boxes will be created as
+    :param box_namespace: the namespace this (possibly nested) Box lives within
     """
 
     _box_config: Dict[str, Any]
@@ -190,6 +192,7 @@ class Box(dict):
         box_recast: Optional[Dict] = None,
         box_dots: bool = False,
         box_class: Optional[Union[Dict, Type["Box"]]] = None,
+        box_namespace: Tuple[str, ...] = (),
         **kwargs: Any,
     ):
         """
@@ -214,6 +217,7 @@ class Box(dict):
                 "box_recast": box_recast,
                 "box_dots": box_dots,
                 "box_class": box_class if box_class is not None else Box,
+                "box_namespace": box_namespace,
             }
         )
         return obj
@@ -235,6 +239,7 @@ class Box(dict):
         box_recast: Optional[Dict] = None,
         box_dots: bool = False,
         box_class: Optional[Union[Dict, Type["Box"]]] = None,
+        box_namespace: Tuple[str, ...] = (),
         **kwargs: Any,
     ):
         super().__init__()
@@ -255,6 +260,7 @@ class Box(dict):
                 "box_recast": box_recast,
                 "box_dots": box_dots,
                 "box_class": box_class if box_class is not None else self.__class__,
+                "box_namespace": box_namespace,
             }
         )
         if not self._box_config["conversion_box"] and self._box_config["box_duplicates"] != "ignore":
@@ -328,6 +334,7 @@ class Box(dict):
         frozen = self._box_config["frozen_box"]
         config = self.__box_config()
         config["frozen_box"] = False
+        config.pop("box_namespace")  # Detach namespace; it will be reassigned if we nest again
         output = self._box_config["box_class"](**config)
         if not isinstance(other, dict):
             raise BoxError("Box can only compare two boxes or a box and a dictionary.")
@@ -430,10 +437,12 @@ class Box(dict):
         return self[key]
 
     def copy(self) -> "Box":
-        return Box(super().copy(), **self.__box_config())
+        config = self.__box_config()
+        config.pop("box_namespace")  # Detach namespace; it will be reassigned if we nest again
+        return Box(super().copy(), **config)
 
     def __copy__(self) -> "Box":
-        return Box(super().copy(), **self.__box_config())
+        return self.copy()
 
     def __deepcopy__(self, memodict=None) -> "Box":
         frozen = self._box_config["frozen_box"]
@@ -454,11 +463,11 @@ class Box(dict):
     def __get_default(self, item, attr=False):
         default_value = self._box_config["default_box_attr"]
         if default_value in (self._box_config["box_class"], dict):
-            value = self._box_config["box_class"](**self.__box_config())
+            value = self._box_config["box_class"](**self.__box_config(extra_namespace=item))
         elif isinstance(default_value, dict):
-            value = self._box_config["box_class"](**self.__box_config(), **default_value)
+            value = self._box_config["box_class"](**self.__box_config(extra_namespace=item), **default_value)
         elif isinstance(default_value, list):
-            value = box.BoxList(**self.__box_config())
+            value = box.BoxList(**self.__box_config(extra_namespace=item))
         elif isinstance(default_value, Callable):
             value = default_value()
         elif hasattr(default_value, "copy"):
@@ -470,11 +479,13 @@ class Box(dict):
                 super().__setitem__(item, value)
         return value
 
-    def __box_config(self) -> Dict:
+    def __box_config(self, extra_namespace: Optional[str] = None) -> Dict:
         out = {}
         for k, v in self._box_config.copy().items():
             if not k.startswith("__"):
                 out[k] = v
+        if extra_namespace is not None:
+            out["box_namespace"] = (*out["box_namespace"], extra_namespace)
         return out
 
     def __recast(self, item, value):
@@ -501,18 +512,20 @@ class Box(dict):
         # This is the magic sauce that makes sub dictionaries into new box objects
         if isinstance(value, dict):
             # We always re-create even if it was already a Box object to pass down configurations correctly
-            value = self._box_config["box_class"](value, **self.__box_config())
+            value = self._box_config["box_class"](value, **self.__box_config(extra_namespace=item))
         elif isinstance(value, list) and not isinstance(value, box.BoxList):
             if self._box_config["frozen_box"]:
                 value = _recursive_tuples(
-                    value, recreate_tuples=self._box_config["modify_tuples_box"], **self.__box_config()
+                    value,
+                    recreate_tuples=self._box_config["modify_tuples_box"],
+                    **self.__box_config(extra_namespace=item),
                 )
             else:
-                value = box.BoxList(value, **self.__box_config())
+                value = box.BoxList(value, **self.__box_config(extra_namespace=item))
         elif isinstance(value, box.BoxList):
-            value.box_options.update(self.__box_config())
+            value.box_options.update(self.__box_config(extra_namespace=item))
         elif self._box_config["modify_tuples_box"] and isinstance(value, tuple):
-            value = _recursive_tuples(value, recreate_tuples=True, **self.__box_config())
+            value = _recursive_tuples(value, recreate_tuples=True, **self.__box_config(extra_namespace=item))
         super().__setitem__(item, value)
 
     def __getitem__(self, item, _ignore_default=False):
@@ -747,12 +760,12 @@ class Box(dict):
             if isinstance(v, dict) and not intact_type:
                 # Box objects must be created in case they are already
                 # in the `converted` box_config set
-                v = self._box_config["box_class"](v, **self.__box_config())
+                v = self._box_config["box_class"](v, **self.__box_config(extra_namespace=k))
                 if k in self and isinstance(self[k], dict):
                     self[k].merge_update(v)
                     return
             if isinstance(v, list) and not intact_type:
-                v = box.BoxList(v, **self.__box_config())
+                v = box.BoxList(v, **self.__box_config(extra_namespace=k))
                 if merge_type == "extend" and k in self and isinstance(self[k], list):
                     self[k].extend(v)
                     return
@@ -786,9 +799,9 @@ class Box(dict):
                 return self[item]
 
         if isinstance(default, dict):
-            default = self._box_config["box_class"](default, **self.__box_config())
+            default = self._box_config["box_class"](default, **self.__box_config(extra_namespace=item))
         if isinstance(default, list):
-            default = box.BoxList(default, **self.__box_config())
+            default = box.BoxList(default, **self.__box_config(extra_namespace=item))
         self[item] = default
         return self[item]
 

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1397,6 +1397,8 @@ class TestBox:
         box.x = {"y": {"z": 5}}
         assert box.x._box_config["box_namespace"] == ("x",)
         assert box.x.y._box_config["box_namespace"] == ("x", "y")
+        box[None][1][2] = 3
+        assert box[None][1]._box_config["box_namespace"] == (None, 1)
 
         for modified_box in [
             box.a + box.x,


### PR DESCRIPTION
I'd like to track the "namespace" of nested boxes, which is hard to do in a subclass because of the (necessary) recursive conversions during `__init__` and other actions. To handle this, I added a new `box_namespace` parameter, which is tracked in `_box_config`, to allow propagating and extending the namespace as we create nested boxes.

Closes #226

---

This recreates https://github.com/cdgriffith/Box/pull/227 after the `develop` branch was replaced. I updated it to avoid creating an intermediate box config when not needed (as per https://github.com/cdgriffith/Box/pull/227#discussion_r946289689). There were two [open questions](https://github.com/cdgriffith/Box/pull/227#issuecomment-1216089919) on how to label elements of lists and whether to add a `box_history` accessor, but I'd be fine 1: punting for now and 2: just accessing the config.
