### PR TITLE
Fix Poetry extras metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,11 @@ wheel = ">=0.34.2"
 
 
 [tool.poetry.extras]
-all = ["ruamel.yaml>=0.17", "tomli; python_version < '3.11'", "tomli-w", "msgpack"]
-yaml = ["ruamel.yaml>=0.17"]
-"ruamel.yaml" = ["ruamel.yaml>=0.17"]
+all = ["ruamel.yaml", "tomli", "tomli-w", "msgpack"]
+yaml = ["ruamel.yaml"]
+"ruamel.yaml" = ["ruamel.yaml"]
 PyYAML = ["PyYAML"]
-tomli = ["tomli; python_version < '3.11'", "tomli-w"]
+tomli = ["tomli", "tomli-w"]
 toml = ["toml"]
 msgpack=  ["msgpack"]
 


### PR DESCRIPTION
The `tool.poetry.extras` fields takes package names, not full names+versions (the version constraints are pulled from the main dependency spec). Apparently, poetry would silently drop invalid (or maybe just unmatched) extra names, so `ruamel` and `tomli`, which had version constraints in the extras name, were not correctly marked as extra.

Here's some of the generated `METADATA` file before:
```
Requires-Dist: PyYAML (>=6.0) ; extra == "pyyaml"
Requires-Dist: msgpack (>=1.0.0) ; extra == "all" or extra == "msgpack"
Requires-Dist: ruamel.yaml (>=0.17)
Requires-Dist: toml (>=0.10.2) ; extra == "toml"
Requires-Dist: tomli (>=1.2.3) ; python_version < "3.11"
Requires-Dist: tomli-w (>=1.0.0) ; extra == "all" or extra == "tomli"
```

and after:
```
Requires-Dist: PyYAML (>=6.0) ; extra == "pyyaml"
Requires-Dist: msgpack (>=1.0.0) ; extra == "all" or extra == "msgpack"
Requires-Dist: ruamel.yaml (>=0.17) ; extra == "all" or extra == "yaml" or extra == "ruamel-yaml"
Requires-Dist: toml (>=0.10.2) ; extra == "toml"
Requires-Dist: tomli (>=1.2.3) ; (python_version < "3.11") and (extra == "all" or extra == "tomli")
Requires-Dist: tomli-w (>=1.0.0) ; extra == "all" or extra == "tomli"
```

Or the diff in the `extras` section in the `poetry.lock`:
```
 [extras]
-all = ["tomli-w", "msgpack"]
+all = ["ruamel.yaml", "tomli", "tomli-w", "msgpack"]
 msgpack = ["msgpack"]
 pyyaml = ["PyYAML"]
-ruamel-yaml = []
+ruamel-yaml = ["ruamel.yaml"]
 toml = ["toml"]
-tomli = ["tomli-w"]
-yaml = []
+tomli = ["tomli", "tomli-w"]
+yaml = ["ruamel.yaml"]
```
