### PR TITLE
Use poetry-core build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ toml = ["toml"]
 msgpack=  ["msgpack"]
 
 [build-system]
-requires = ["poetry>=0.12", "Cython", "setuptools", "wheel"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0", "Cython", "setuptools", "wheel"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Switch from the obsolete `poetry` build backend to `poetry-core`. They are functionally equivalent, except that the latter pulls much fewer dependencies in the virtualenv used to build wheels.  See: https://python-poetry.org/docs/pyproject/#poetry-and-pep-517