### PR TITLE
Stop installing docs straight into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ version = "7.0.0"
 description = "Advanced Python dictionaries with dot notation access"
 license = "MIT"
 authors = ["Chris Griffith <chris@cdgriffith.com>", ]
-include = ["box_logo.png", "AUTHORS.rst", "CHANGES.rst", "LICENSE"]
+include = [
+        { path = "box_logo.png", format = "sdist" },
+        { path = "AUTHORS.rst", format = "sdist" },
+        { path = "CHANGES.rst", format = "sdist" },
+        { path = "LICENSE", format = "sdist" },
+]
 readme = "README.rst"
 repository = "https://github.com/cdgriffith/Box"
 build = "build.py"


### PR DESCRIPTION
Fix the `include` entries in `pyproject.toml` to limit documentation files to the sdist format.  Otherwise, they are included top-level in the generated wheels, and end up being installed straight into site-packages, e.g.:

    /usr/lib/python3.11/site-packages/LICENSE
    /usr/lib/python3.11/site-packages/CHANGES.rst
    /usr/lib/python3.11/site-packages/AUTHORS.rst