### PR TITLE
Fixing #251 support for circular references in lists

### DIFF
--- a/box/box_list.py
+++ b/box/box_list.py
@@ -40,6 +40,7 @@ class BoxList(list):
         # This is required for pickling to work correctly
         obj.box_options = {"box_class": box.Box}
         obj.box_options.update(kwargs)
+        obj.box_org_ref = None
         return obj
 
     def __init__(self, iterable: Optional[Iterable] = None, box_class: Type[box.Box] = box.Box, **box_options):

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -40,16 +40,16 @@ class BoxList(list):
         # This is required for pickling to work correctly
         obj.box_options = {"box_class": box.Box}
         obj.box_options.update(kwargs)
-        obj.box_org_ref = 0
         return obj
 
     def __init__(self, iterable: Optional[Iterable] = None, box_class: Type[box.Box] = box.Box, **box_options):
         self.box_options = box_options
         self.box_options["box_class"] = box_class
-        self.box_org_ref = id(iterable) if iterable else 0
+        self.box_org_ref = iterable
         if iterable:
             for x in iterable:
                 self.append(x)
+        self.box_org_ref = None
         if box_options.get("frozen_box"):
 
             def frozen(*args, **kwargs):
@@ -101,7 +101,7 @@ class BoxList(list):
         elif isinstance(p_object, box.Box):
             p_object._box_config.update(self.box_options)
         if isinstance(p_object, list) and not self._is_intact_type(p_object):
-            p_object = self.__class__(p_object, **self.box_options)
+            p_object = self if p_object is self or p_object is self.box_org_ref else self.__class__(p_object, **self.box_options)
         elif isinstance(p_object, BoxList):
             p_object.box_options.update(self.box_options)
         return p_object

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -228,10 +228,8 @@ class TestBoxList:
         a.list_of_dicts.append([{"example2": 2}])
         assert a["list_of_dicts"][1] == [{"example2": 2}]
 
-    def test_no_circular_references(self):
-        if sys.version_info >= (3, 12) and sys.platform == "win32":
-            pytest.skip("Windows fatal exception: stack overflow on github actions")
+    def test_circular_references(self):
         circular_list = []
         circular_list.append(circular_list)
-        with pytest.raises(RecursionError):
-            BoxList(circular_list)
+        circular_box = BoxList(circular_list)
+        assert circular_box[0] == circular_box


### PR DESCRIPTION
I read #251 and think that using `is` operator to identify objects may fix the problem `id` brings.

For now, you can:

1. initialize a `BoxList` with a list with circular references

```py
>>> from box import BoxList
>>> a = []
>>> a.append(a)
>>> a
[[...]]
>>> b = BoxList(a)
>>> b
BoxList([[...]])
>>> b[0][0][0][0] is b
True
```

2. reference oneself after creation

```py
>>> a = BoxList()
>>> a
BoxList([])
>>> a.append(a)
>>> a
BoxList([[...]])
>>> a[0][0][0][0] is a
True
```

Note this:

```py
>>> a = []
>>> b = BoxList(a)
>>> b.append(a)
>>> b
BoxList([[]])
>>> b[0] is a
False
```

This is because:

1. For performance, it is a waste to always hold a reference for the `iterable` passing to `__init__`.
2. After initialization, `a` is not the same as `b` anymore, I think users appending `b` to `a` is not intended to append `a` to `a`.