### PR TITLE
Add support for accessing nested items in BoxList using numpy-style tuple indexing.

### DIFF
--- a/box/box_list.py
+++ b/box/box_list.py
@@ -65,6 +65,11 @@ class BoxList(list):
             if len(list_pos.group()) == len(item):
                 return value
             return value.__getitem__(item[len(list_pos.group()) :].lstrip("."))
+        if isinstance(item, tuple):
+            result = self
+            for i in item:
+                result = result[i]
+            return result
         return super().__getitem__(item)
 
     def __delitem__(self, key):

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -67,8 +67,11 @@ class BoxList(list):
             return value.__getitem__(item[len(list_pos.group()) :].lstrip("."))
         if isinstance(item, tuple):
             result = self
-            for i in item:
-                result = result[i]
+            for idx in item:
+                if isinstance(result, list):
+                    result = result[idx]
+                else:
+                    raise BoxTypeError(f"Cannot numpy-style indexing on {type(result).__name__}.")
             return result
         return super().__getitem__(item)
 

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -37,6 +37,8 @@ class TestBoxList:
         assert new_list[-1][0].bad_item == 33
         new_list[-1].append([{"bad_item": 33}])
         assert new_list[-1, -1, 0].bad_item == 33
+        bx = Box({0: {1: {2: {3: 3}}}, (0, 1, 2, 3): 4})
+        assert bx[0, 1, 2, 3] == 4
         assert repr(new_list).startswith("BoxList(")
         for x in new_list.to_list():
             assert not isinstance(x, (BoxList, Box))

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -35,6 +35,8 @@ class TestBoxList:
         assert new_list[-1].item == 22
         new_list.append([{"bad_item": 33}])
         assert new_list[-1][0].bad_item == 33
+        new_list[-1].append([{"bad_item": 33}])
+        assert new_list[-1, -1, 0].bad_item == 33
         assert repr(new_list).startswith("BoxList(")
         for x in new_list.to_list():
             assert not isinstance(x, (BoxList, Box))


### PR DESCRIPTION
Allow BoxList to use numpy-style tuple indexing, similar to `l[0,1,2,3]`, which is equivalent to `l[0][1][2][3]`.