### PR TITLE
Altering __repr__ methods to accurately represent subclass names

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,6 +30,7 @@ Code contributions:
 - Michał Górny (mgorny)
 - Serge Lu (Serge45)
 - Eric Prestat (ericpre)
+- Gabriel Mitelman Tkacz (gtkacz)
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 7.1.2
+-------------
+
+* Fixing #261 altering all `__repr__` methods so that subclassing will output the correct class name
+
 Version 7.1.1
 -------------
 

--- a/box/box.py
+++ b/box/box.py
@@ -777,7 +777,7 @@ class Box(dict):
         return key, self.pop(key)
 
     def __repr__(self) -> str:
-        return f"Box({self})"
+        return f"{self.__class__.__name__}({self})"
 
     def __str__(self) -> str:
         return str(self.to_dict())

--- a/box/box_list.py
+++ b/box/box_list.py
@@ -133,7 +133,7 @@ class BoxList(list):
         return keys
 
     def __repr__(self):
-        return f"BoxList({self.to_list()})"
+        return f"{self.__class__.__name__}({self.to_list()})"
 
     def __str__(self):
         return str(self.to_list())

--- a/box/config_box.py
+++ b/box/config_box.py
@@ -124,7 +124,7 @@ class ConfigBox(Box):
         return self.float(item, default)
 
     def __repr__(self):
-        return "ConfigBox({0})".format(str(self.to_dict()))
+        return f"{self.__class__.__name__}({str(self.to_dict())})"
 
     def copy(self):
         return ConfigBox(super().copy())

--- a/box/shorthand_box.py
+++ b/box/shorthand_box.py
@@ -44,7 +44,7 @@ class SBox(Box):
         return self.to_toml()
 
     def __repr__(self):
-        return f"SBox({self})"
+        return f"{self.__class__.__name__}({self})"
 
     def copy(self) -> "SBox":
         return SBox(super(SBox, self).copy())
@@ -66,4 +66,4 @@ class DDBox(SBox):
         return obj
 
     def __repr__(self) -> str:
-        return f"DDBox({self})"
+        return f"{self.__class__.__name__}({self})"


### PR DESCRIPTION
All Box classes have their class names hardcoded into their respective `__repr__` methods, making it so that when subclassing, `__repr__` calls will output the original class names, which is confusing.

Example:

```python
from box import Box


class MyBox(Box):
    pass


class ActuallyMyBox(Box):
    def __repr__(self):
        return f"{type(self).__name__}({self})"


b1 = MyBox(a=1)
b2 = ActuallyMyBox(b=2)
print(repr(b1))
print(repr(b2))

>>> Box({'a': 1})
>>> ActuallyMyBox({'b': 2})
```

Closes #261 