### PR TITLE
fix: adding frozen boxes

### DIFF
--- a/box/box.py
+++ b/box/box.py
@@ -839,7 +839,10 @@ class Box(dict):
                 # in the `converted` box_config set
                 v = self._box_config["box_class"](v, **self.__box_config(extra_namespace=k))
                 if k in self and isinstance(self[k], dict):
+                    frozen = self[k]._box_config['frozen_box']
+                    self[k]._box_config['frozen_box'] = False
                     self[k].merge_update(v, box_merge_lists=merge_type)
+                    self[k]._box_config['frozen_box'] = frozen
                     return
             if isinstance(v, list) and not intact_type:
                 v = box.BoxList(v, **self.__box_config(extra_namespace=k))

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -984,6 +984,11 @@ class TestBox:
         with pytest.raises(BoxError):
             Box() + BoxList()
 
+    def test_add_frozen_boxes(self):
+        b = Box(c=1, d={"sub": 1}, e=1, frozen_box=True)
+        c = dict(d={"val": 2}, e=4)
+        assert b + c == Box(c=1, d={"sub": 1, "val": 2}, e=4)
+
     def test_iadd_boxes(self):
         b = Box(c=1, d={"sub": 1}, e=1)
         c = dict(d={"val": 2}, e=4)


### PR DESCRIPTION
Fix #291

I'm not entirely convinced this solution is valid. Maybe the merge_update function should accept a frozen_merge keyword argument. This argument would be set to True in the __add__ method, allowing all the new code to be conditional within an if statement.?