### PR TITLE
Add 'box_dots_exclude' parameter to keep certain keys with dots from being broken down

### DIFF
--- a/box/converters.py
+++ b/box/converters.py
@@ -119,6 +119,7 @@ BOX_PARAMETERS = (
     "box_duplicates",
     "box_intact_types",
     "box_dots",
+    "box_dots_exclude",
     "box_recast",
     "box_class",
     "box_namespace",

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -936,6 +936,13 @@ class TestBox:
         with pytest.raises(BoxKeyError):
             del b["a.b"]
 
+    def test_dots_exclusion(self):
+        bx = Box.from_yaml(yaml_string="0.0.0.1: True",default_box=True,default_box_none_transform=False,box_dots=True,
+                           box_dots_exclude=r'[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+        assert bx["0.0.0.1"] == True
+        with pytest.raises(BoxKeyError):
+          del bx["0"]
+
     def test_unicode(self):
         bx = Box()
         bx["\U0001f631"] = 4


### PR DESCRIPTION
Fixes #295 - use case is using IP addresses as keys in a Box with dot functionality enabled