### PR TITLE
Preserve Box subclass for nested boxes after unpickling

### DIFF
--- a/box/box.py
+++ b/box/box.py
@@ -233,7 +233,7 @@ class Box(dict):
                 "box_recast": box_recast,
                 "box_dots": box_dots,
                 "box_dots_exclude": re.compile(box_dots_exclude) if box_dots_exclude else None,
-                "box_class": box_class if box_class is not None else Box,
+                "box_class": box_class if box_class is not None else cls,
                 "box_namespace": box_namespace,
             }
         )

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -32,6 +32,10 @@ from box.box import _get_dot_paths, _camel_killer, _recursive_tuples  # type: ig
 from box.converters import BOX_PARAMETERS
 
 
+class _SubclassBox(Box):
+    """Module-level Box subclass so its instances are picklable in tests."""
+
+
 def mp_queue_test(q):
     bx = q.get()
     try:
@@ -685,6 +689,17 @@ class TestBox:
         loaded2 = pickle.load(open(pic2_file, "rb"))
         assert bx == loaded2
         loaded2.box_options = bx.box_options
+
+    def test_pickle_preserves_subclass_on_nested_access(self):
+        if platform.python_implementation() == "PyPy":
+            pytest.skip("Pickling does not work correctly on PyPy")
+        # Unpickling goes through __new__ + __setstate__ but not __init__, so
+        # box_class must be set from cls in __new__ too. Otherwise nested boxes
+        # created on access after unpickling fall back to the base Box (#308).
+        b = _SubclassBox({"a": {"b": 1}})
+        loaded = pickle.loads(pickle.dumps(b))
+        assert isinstance(loaded, _SubclassBox)
+        assert type(loaded.a) is _SubclassBox
 
     def test_pickle_default_box(self):
         if platform.python_implementation() == "PyPy":


### PR DESCRIPTION
Fixes #308.

A `Box` subclass is lost on nested attribute access after unpickling: nested boxes come back as the base `box.box.Box` instead of the subclass.

`Box.__init__` sets `box_class` from `self.__class__`:

```python
# __init__
"box_class": box_class if box_class is not None else self.__class__,
```

but `Box.__new__` hardcodes the base `Box`:

```python
# __new__
"box_class": box_class if box_class is not None else Box,
```

Unpickling calls `__new__` + `__setstate__`, not `__init__`, so a subclass instance is restored with `box_class=Box`. Nested dicts converted to boxes on access (conversion box) then use `box_class`, producing base `Box` objects. Using `cls` in `__new__` (which is the actual subclass) matches `__init__`.

Added `test_pickle_preserves_subclass_on_nested_access`: pickles a `Box` subclass with a nested dict and asserts the nested box is still the subclass after a round-trip. It fails on `master` (nested box is base `Box`) and passes with the fix; existing pickle tests still pass. (The subclass is defined at module level so its instances are picklable.)
