### PR TITLE
fix: preserve existing keys on dotted list-element writes

### DIFF
--- a/box/box_list.py
+++ b/box/box_list.py
@@ -106,9 +106,15 @@ class BoxList(list):
                 return super().__setitem__(pos, value)
             children = key[len(list_pos.group()) :].lstrip(".")
             if self.box_options.get("default_box"):
+                # Only replace the element at ``pos`` with a fresh container when it is
+                # not already the right one; otherwise a second dotted write into an
+                # existing element (e.g. ``a[0].y`` after ``a[0].x``) would discard the
+                # data already stored there. Mirrors the guard in Box.__setitem__.
+                current = super().__getitem__(pos)
                 if children[0] == "[":
-                    super().__setitem__(pos, box.BoxList(**self.box_options))
-                else:
+                    if not isinstance(current, box.BoxList):
+                        super().__setitem__(pos, box.BoxList(**self.box_options))
+                elif not isinstance(current, box.Box):
                     super().__setitem__(pos, self.box_options.get("box_class")(**self.box_options))
             return super().__getitem__(pos).__setitem__(children, value)
         super().__setitem__(key, value)

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -241,6 +241,24 @@ class TestBoxList:
         box_3["a.b[0]"] = 42
         assert box_3.a.b[0] == 42
 
+        # A second dotted write into an existing list element must not discard
+        # the keys already written there (regression).
+        box_4 = Box(default_box=True, box_dots=True)
+        box_4["a[0].x"] = 1
+        box_4["a[0].y"] = 2
+        assert box_4.a[0].to_dict() == {"x": 1, "y": 2}
+
+        box_5 = Box(default_box=True, box_dots=True)
+        box_5["a[0][0].x"] = 1
+        box_5["a[0][1].y"] = 2
+        assert box_5.a[0].to_list() == [{"x": 1}, {"y": 2}]
+
+        # A scalar already at the position is still overwritten.
+        box_6 = Box(default_box=True, box_dots=True)
+        box_6["a[0]"] = 5
+        box_6["a[0].x"] = 1
+        assert box_6.a[0].to_dict() == {"x": 1}
+
     def test_box_config_propagate(self):
         structure = Box(a=[Box(default_box=False)], default_box=True, box_inherent_settings=True)
         assert structure._box_config["default_box"] is True


### PR DESCRIPTION
## Summary

With `default_box=True` and `box_dots=True`, writing a second dotted key into an **already-existing** list element silently discards the keys already written there:

```python
from box import Box
b = Box(default_box=True, box_dots=True)
b["a[0].x"] = 1     # {'a': [{'x': 1}]}
b["a[0].y"] = 2
b.to_dict()         # {'a': [{'y': 2}]}   <-- 'x' is gone, expected {'a': [{'x': 1, 'y': 2}]}
```

The write succeeds but drops previously-stored data — a silent correctness/data-loss bug. (Different indices like `a[0].x` then `a[1].y` are fine; the bug is a second write to the *same* index.)

## Cause

`BoxList.__setitem__` (`box/box_list.py`), in the `default_box` branch, **unconditionally** replaces the element at the target index with a fresh empty `Box`/`BoxList` before recursing into it — even when a populated container already lives there. So the second write to `a[0]` throws away the `Box({'x': 1})` already stored and recurses into a brand-new empty one.

The sibling `Box.__setitem__` already guards this with an "is it already the right container?" check; the `BoxList` path was missing it.

## Fix

Read the current element first and only replace it when it isn't already the right container type. A scalar (or `None` placeholder from list extension) is still correctly overwritten; an existing `Box`/`BoxList` is preserved and recursed into.

Added regression coverage to `test_box_list_default_dots` (two keys into one element, nested list-in-list, and the scalar-overwrite case). Full suite: 154 passed; the 5 `test_toon_*` failures are pre-existing (a `NotImplementedError`/`BoxError` from the third-party `toon_format` package) and reproduce identically on a clean `master`. `black --config=.black.toml --check` clean.

This pull request was prepared with the assistance of AI, under my direction and review.
