### PR TITLE
fix: expose ruamel_typ and ruamel_attrs in to_yaml method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 7.4.1
+-------------
+
+* Fixing #303 Wrong version number (7.3.3) in 7.4.0 release (thanks to Michał Górny)
+
 Version 7.4.0
 -------------
 
@@ -10,6 +15,11 @@ Version 7.4.0
 * Adding support for Python 3.14
 * Fixing #291 adding frozen boxes (thanks to m-janicki)
 * Removing support for Python 3.9 as it is EOL
+
+Version 7.3.3
+-------------
+
+* Mistakenly released 7.4.0 as 7.3.3 in PyPI, same as above
 
 Version 7.3.2
 -------------

--- a/box/__init__.py
+++ b/box/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 __author__ = "Chris Griffith"
-__version__ = "7.3.3"
+__version__ = "7.4.1"
 
 from box.box import Box
 from box.box_list import BoxList

--- a/box/box.py
+++ b/box/box.py
@@ -1022,6 +1022,8 @@ class Box(dict):
             encoding: str = "utf-8",
             errors: str = "strict",
             width: int = 120,
+            ruamel_typ: str = "rt",
+            ruamel_attrs: dict | None = None,
             **yaml_kwargs,
         ):
             """
@@ -1032,6 +1034,8 @@ class Box(dict):
             :param encoding: File encoding
             :param errors: How to handle encoding errors
             :param width: Line width for YAML output
+            :param ruamel_typ: ruamel.yaml parser type (default "rt")
+            :param ruamel_attrs: Additional attributes to set on the ruamel dumper
             :param yaml_kwargs: additional arguments to pass to yaml.dump
             :return: string of YAML (if no filename provided)
             """
@@ -1042,6 +1046,8 @@ class Box(dict):
                 encoding=encoding,
                 errors=errors,
                 width=width,
+                ruamel_typ=ruamel_typ,
+                ruamel_attrs=ruamel_attrs,
                 **yaml_kwargs,
             )
 


### PR DESCRIPTION
## Description

The `_to_yaml` function already supports `ruamel_typ` and `ruamel_attrs` parameters for configuring ruamel.yaml's parser behavior, but `Box.to_yaml()` didn't expose these. This made it impossible for users to customize ruamel.yaml settings (e.g., increasing the `width` to prevent unwanted line wrapping of long scalar values).

## Changes

- `box/box.py`: Added `ruamel_typ` and `ruamel_attrs` parameters to `to_yaml()` and passed them through to `_to_yaml()`

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #307