### PR TITLE
fix: preserve subclass identity when unpickling Box

### DIFF
--- a/box/box.py
+++ b/box/box.py
@@ -233,7 +233,7 @@ class Box(dict):
                 "box_recast": box_recast,
                 "box_dots": box_dots,
                 "box_dots_exclude": re.compile(box_dots_exclude) if box_dots_exclude else None,
-                "box_class": box_class if box_class is not None else Box,
+                "box_class": box_class if box_class is not None else cls,
                 "box_namespace": box_namespace,
             }
         )


### PR DESCRIPTION
## Description

When a subclass of Box is pickled and unpickled, nested Box objects within it were reconstructed as the base `Box` class instead of the subclass. The `__new__` method hardcoded `Box` as the default `box_class` instead of using `cls`, which is the actual class being instantiated.

## Changes

- `box/box.py`: Changed `Box` to `cls` in `__new__` method's `box_class` default assignment

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #308