### PR TITLE
Fix serialization of frozen_box with nested lists (#272)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fixing #272 ``frozen_box`` with nested lists could not be serialized to YAML (thanks to apoorvdarshan)
+
 Version 7.4.1
 -------------
 

--- a/box/box.py
+++ b/box/box.py
@@ -97,6 +97,25 @@ def _recursive_tuples(iterable, box_class, recreate_tuples=False, **kwargs):
     return tuple(out_list)
 
 
+def _to_native_tuple(iterable):
+    """Convert a tuple's Box/BoxList members back to native types.
+
+    ``frozen_box`` stores lists as tuples of Boxes, so ``to_dict`` needs to
+    turn those nested Boxes back into plain dicts to remain serializable.
+    """
+    out_list = []
+    for i in iterable:
+        if isinstance(i, Box):
+            out_list.append(i.to_dict())
+        elif isinstance(i, box.BoxList):
+            out_list.append(i.to_list())
+        elif isinstance(i, tuple):
+            out_list.append(_to_native_tuple(i))
+        else:
+            out_list.append(i)
+    return tuple(out_list)
+
+
 def _parse_box_dots(bx, item, setting=False):
     for idx, char in enumerate(item):
         if char == "[":
@@ -815,6 +834,8 @@ class Box(dict):
                 out_dict[k] = v.to_dict()
             elif isinstance(v, box.BoxList):
                 out_dict[k] = v.to_list()
+            elif isinstance(v, tuple):
+                out_dict[k] = _to_native_tuple(v)
         return out_dict
 
     def update(self, *args, **kwargs):

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -435,6 +435,22 @@ class TestBox:
 
         assert hash(bx3)
 
+    def test_frozen_box_with_lists_is_serializable(self):
+        # frozen_box stores lists as tuples of Boxes; to_dict must convert the
+        # nested Boxes back to native dicts so serialization works. See #272.
+        bx = Box({"a": [{"b": 123}, {"b": 222}], "c": [[{"d": 2}], [3, 4]]}, frozen_box=True)
+
+        native = bx.to_dict()
+        assert isinstance(native["a"], tuple)
+        assert native["a"][0] == {"b": 123}
+        assert not isinstance(native["a"][0], Box)
+        assert not isinstance(native["c"][0][0], Box)
+
+        # These used to raise RepresenterError / serialization errors.
+        yaml = YAML(typ="safe")
+        assert yaml.load(bx.to_yaml()) == {"a": [{"b": 123}, {"b": 222}], "c": [[{"d": 2}], [3, 4]]}
+        assert json.loads(bx.to_json()) == {"a": [{"b": 123}, {"b": 222}], "c": [[{"d": 2}], [3, 4]]}
+
     def test_hashing(self):
         bx1 = Box(t=3, g=4, frozen_box=True)
         bx2 = Box(g=4, t=3, frozen_box=True)


### PR DESCRIPTION
Fixes #272.

## Problem

A `frozen_box` containing lists can't be serialized to YAML:

```python
from box import Box
Box({'a': [{'b': 123}, {'b': 222}]}, frozen_box=True).to_yaml()
# ruamel.yaml.representer.RepresenterError: cannot represent an object: Box({'b': 123})
```

## Root cause

`frozen_box` freezes lists into **tuples of Boxes** for immutability (via `_recursive_tuples`). But `Box.to_dict()` only recurses into `Box` and `BoxList` values — not tuples:

```python
for k, v in out_dict.items():
    if v is self: ...
    elif isinstance(v, Box):     out_dict[k] = v.to_dict()
    elif isinstance(v, box.BoxList): out_dict[k] = v.to_list()
    # tuples fall through unchanged
```

So the nested `Box` objects stay inside the tuple, and `ruamel.yaml` has no representer for a `Box`, hence the error. (`to_json()` happens to work because `Box` is a `dict` subclass, but the underlying `to_dict()` gap is the real defect.)

## Fix

Recurse into tuples in `to_dict()`, converting their nested `Box`/`BoxList` members back to native types — **while preserving the tuple** (so explicit, non-frozen tuple values are unaffected). A small `_to_native_tuple` helper mirrors the existing `_recursive_tuples` (its input-side inverse) and handles nested tuples.

## Testing

- Added `test_frozen_box_with_lists_is_serializable`: a `frozen_box` with nested lists now produces native, serializable output and round-trips through both YAML and JSON. It fails on `master` (nested value is a `Box`) and passes with this change.
- Verified no behavior change for **non-frozen explicit tuples** — `Box({'a': (1, 2)}).to_dict()` still returns `{'a': (1, 2)}`.
- Full test suite passes (`155 passed`). The only failures in a full run are 5 pre-existing `to_toon` tests that require the optional `toon_format` package (they fail identically on `master` here and are unrelated).
- `black` (via `.black.toml`) is clean on the changed lines.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I reproduced the issue, root-caused it, implemented and verified the fix and test, ran the suite and formatter, and take responsibility for the contribution and will respond to review feedback personally.*
