### PR TITLE
Preserve box options in BoxList.__deepcopy__

### DIFF
--- a/box/box_list.py
+++ b/box/box_list.py
@@ -169,11 +169,14 @@ class BoxList(list):
         return self.__class__((x for x in self), **self.box_options)
 
     def __deepcopy__(self, memo=None):
-        out = self.__class__()
+        frozen = self.box_options.get("frozen_box")
+        out = self.__class__(**{**self.box_options, "frozen_box": False})
         memo = memo or {}
         memo[id(self)] = out
         for k in self:
             out.append(copy.deepcopy(k, memo=memo))
+        if frozen:
+            out.__init__(**self.box_options)
         return out
 
     def __hash__(self) -> int:  # type: ignore[override]

--- a/test/test_box_list.py
+++ b/test/test_box_list.py
@@ -74,6 +74,28 @@ class TestBoxList:
         bl2[1] = 4
         assert bl2[1] == 4
 
+    def test_deepcopy_preserves_box_options(self):
+        import copy
+
+        # deepcopy must preserve box_options, matching __copy__ and Box.__deepcopy__
+        for options in (
+            {"frozen_box": True},
+            {"box_dots": True},
+            {"default_box": True},
+            {"box_intact_types": (dict,)},
+        ):
+            bl = BoxList([{"a": 1}], **options)
+            key = list(options)[0]
+            assert copy.copy(bl).box_options.get(key) == options[key]
+            assert copy.deepcopy(bl).box_options.get(key) == options[key]
+
+        # a frozen BoxList must stay frozen (immutable + hashable) after deepcopy
+        frozen = BoxList([5, 4, 3], frozen_box=True)
+        clone = copy.deepcopy(frozen)
+        with pytest.raises(BoxError):
+            clone.append(1)
+        assert hash(clone) == hash(frozen)
+
     def test_box_list_to_json(self):
         bl = BoxList([{"item": 1, "CamelBad": 2}])
         assert json.loads(bl.to_json())[0]["item"] == 1


### PR DESCRIPTION
`BoxList.__deepcopy__` builds the copy as `self.__class__()` with no `box_options`, so `copy.deepcopy()` silently drops every option:

```python
import copy
from box import BoxList
d = copy.deepcopy(BoxList([1, 2, 3], frozen_box=True))
d.box_options.get("frozen_box")   # None  — frozen_box lost
d.append(4)                        # succeeds -> [1, 2, 3, 4]  — immutability broken (and now unhashable)
```

It's a three-way inconsistency: `BoxList.__copy__` preserves options, `Box.__deepcopy__` preserves options (and re-applies `frozen`), but `BoxList.__deepcopy__` does neither. It's also reachable indirectly — `copy.deepcopy` of a `Box` that contains a nested `BoxList` loses that BoxList's options.

**Fix** (`box/box_list.py`): mirror `Box.__deepcopy__` — build the copy **unfrozen** (so `append` works while populating), register it in `memo` **before** recursing (preserves the existing self-reference/cycle safety), populate, then re-freeze via `__init__`.

**Verification** (re-runnable from the diff): added `test_deepcopy_preserves_box_options` — it checks `copy.deepcopy` preserves `frozen_box`/`box_dots`/`default_box`/`box_intact_types` (parity with `copy.copy`), and that a deepcopied frozen BoxList still raises on `append` and hashes equal. It fails on the current tree and passes with the fix. `test/test_box_list.py` goes from 18 to 19 passing with no new failures (the 2 pre-existing failures are `test_toon_*`, an optional `toon` dep not installed — identical before and after).

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
