### PR TITLE
Fix nested boxes losing box_dots after pickle (#260)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ Code contributions:
 - Jesper Schlegel (jesperschlegel)
 - J vanBemmel (jbemmel)
 - m-janicki
+- DSeaStar (DSeaStar)
 
 
 Suggestions and bug reporting:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 7.4.2
+-------------
+
+* Fixing #260 nested boxes lose ``box_dots`` (and other options) after pickle (thanks to DSeaStar)
+
 Version 7.4.1
 -------------
 

--- a/box/box.py
+++ b/box/box.py
@@ -237,6 +237,10 @@ class Box(dict):
                 "box_namespace": box_namespace,
             }
         )
+        # Pickle reconstructs via __new__ + item assignment + __setstate__.
+        # Item assignment happens first, while this Box still has default options,
+        # so nested Box/BoxList values must be stored as-is (see __convert_and_store).
+        obj._box_config["__unpickling"] = True
         return obj
 
     def __init__(
@@ -491,6 +495,8 @@ class Box(dict):
     def __setstate__(self, state):
         self._box_config = state["_box_config"]
         self.__dict__.update(state)
+        self._box_config["__created"] = True
+        self._box_config["__unpickling"] = False
 
     def __process_dotted_key(self, item):
         if self._box_config["box_dots"] and isinstance(item, str):
@@ -580,6 +586,11 @@ class Box(dict):
             return super().__setitem__(item, value)
         # If the value has already been converted or should not be converted, return it as-is
         if self._box_config["box_intact_types"] and isinstance(value, self._box_config["box_intact_types"]):
+            return super().__setitem__(item, value)
+        # Pickle sets items before __setstate__, so this Box still has default
+        # options. Nested Box/BoxList objects already carry the correct config
+        # from their own unpickle; recreating them here would drop box_dots etc.
+        if self._box_config.get("__unpickling") and isinstance(value, (Box, box.BoxList)):
             return super().__setitem__(item, value)
         # This is the magic sauce that makes sub dictionaries into new box objects
         if isinstance(value, dict):

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -693,6 +693,37 @@ class TestBox:
         loaded = pickle.loads(pickle.dumps(bb))
         assert bb == loaded
 
+    def test_pickle_preserves_nested_box_dots(self):
+        """Nested boxes must keep box_dots after pickle (#260)."""
+        if platform.python_implementation() == "PyPy":
+            pytest.skip("Pickling does not work correctly on PyPy")
+        original = Box(
+            {
+                "l1": {
+                    "time_range_selected_utc": {
+                        "left": "2023-03-01 10:00:00",
+                        "right": "2023-06-01 10:00:00",
+                    }
+                }
+            },
+            box_dots=True,
+            conversion_box=False,
+        )
+        assert original["l1.time_range_selected_utc.right"] == "2023-06-01 10:00:00"
+
+        loaded = pickle.loads(pickle.dumps(original))
+        assert loaded._box_config["box_dots"] is True
+        assert loaded.l1._box_config["box_dots"] is True
+        assert loaded.l1.time_range_selected_utc._box_config["box_dots"] is True
+        assert loaded["l1.time_range_selected_utc.right"] == "2023-06-01 10:00:00"
+        assert loaded["l1.time_range_selected_utc.left"] == "2023-03-01 10:00:00"
+
+        # Normal construction still reapplies parent options onto a nested Box
+        inner = Box({"b": 1}, box_dots=False)
+        outer = Box({"a": inner}, box_dots=True)
+        assert outer.a._box_config["box_dots"] is True
+        assert outer["a.b"] == 1
+
     def test_conversion_dup_only(self):
         with pytest.raises(BoxError):
             Box(movie_data, conversion_box=False, box_duplicates="error")


### PR DESCRIPTION
## Summary

Pickle reconstructs a `Box` with `__new__`, then assigns items, then calls `__setstate__`. Item assignment goes through `__setitem__` / `__convert_and_store`, which rebuilds nested `Box` values using the parent’s still-default options (`box_dots=False`). `__setstate__` then restores only the outer box, so dotted lookups on cached/unpickled trees fail.

This matches the owner’s diagnosis on #260: after pickle, only the outermost box keeps `box_dots=True`.

The fix keeps already-unpickled nested `Box` / `BoxList` values as-is while `__unpickling` is set (cleared in `__init__` and `__setstate__`). Normal construction still re-applies parent options onto a nested `Box`.

## Test plan

- [x] Added `test_pickle_preserves_nested_box_dots` using the #260 example (`l1.time_range_selected_utc.right` after `pickle.loads(pickle.dumps(...))`)
- [x] Existing pickle tests still pass
- [x] Constructor still reapplies `box_dots` when wrapping an existing nested `Box`

Fixes #260