### PR TITLE
Add a "merge" option for box_merge_lists (#263)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -98,3 +98,4 @@ Suggestions and bug reporting:
 - d00m514y3r
 - Sébastien Weber (seb5g)
 - Ward Loos (wrdls)
+- Chris (ChrisJr404)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Adding #263 ``"merge"`` option for ``box_merge_lists`` to merge lists of dictionaries element by element
+
 Version 7.4.1
 -------------
 

--- a/box/box.py
+++ b/box/box.py
@@ -834,6 +834,27 @@ class Box(dict):
             self.__convert_and_store(k, kwargs[k])
 
     def merge_update(self, *args, **kwargs):
+        """
+        Recursively update the Box, merging nested dictionaries instead of
+        overwriting them like the built-in ``dict.update``.
+
+        The ``box_merge_lists`` keyword controls how lists sharing a key are
+        combined:
+
+        * ``None`` (default) - the incoming list replaces the existing one
+        * ``"extend"`` - the incoming items are appended to the existing list
+        * ``"unique"`` - only incoming items not already present are appended
+        * ``"merge"`` - lists are merged element by element, recursing into
+          dictionaries that share the same index so their keys are combined
+
+        .. code-block:: python
+
+            box_one = Box({"data": [{"a": 1}, {"b": 2}]})
+            box_one.merge_update({"data": [{"c": 3}]}, box_merge_lists="merge")
+            # Box({'data': [{'a': 1, 'c': 3}, {'b': 2}]})
+
+        :param box_merge_lists: strategy used to merge lists, see above
+        """
         merge_type = None
         if "box_merge_lists" in kwargs:
             merge_type = kwargs.pop("box_merge_lists")
@@ -864,6 +885,17 @@ class Box(dict):
                     if merge_type == "unique" and k in self and isinstance(self[k], list):
                         for item in v:
                             if item not in self[k]:
+                                self[k].append(item)
+                        return
+                    if merge_type == "merge" and k in self and isinstance(self[k], list):
+                        for index, item in enumerate(v):
+                            if index < len(self[k]) and isinstance(self[k][index], dict) and isinstance(item, dict):
+                                self[k][index].merge_update(
+                                    item, box_merge_lists=merge_type, _force_unfrozen=force_unfrozen
+                                )
+                            elif index < len(self[k]):
+                                self[k][index] = item
+                            else:
                                 self[k].append(item)
                         return
                 self.__setitem__(k, v)

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1328,6 +1328,27 @@ class TestBox:
             {"app": {"S3": {"S3Service": [{"bucket": "bucket001"}, {"expirationDate": "2099-10-25"}]}}}
         ), box1
 
+    def test_merge_list_merge_option(self):
+        # Lists of dictionaries are merged element by element
+        box1 = Box({"data": [{"foo": 1, "foobar": 20}, {"bar": 2}]})
+        box1.merge_update({"data": [{"foo": 1, "baz": 10}]}, box_merge_lists="merge")
+        assert box1 == Box({"data": [{"foo": 1, "foobar": 20, "baz": 10}, {"bar": 2}]}), box1
+
+        # Extra incoming elements are appended, nested dictionaries recurse
+        box2 = Box({"app": {"servers": [{"name": "web", "tags": {"a": 1}}]}})
+        box2.merge_update({"app": {"servers": [{"tags": {"b": 2}}, {"name": "db"}]}}, box_merge_lists="merge")
+        assert box2 == Box({"app": {"servers": [{"name": "web", "tags": {"a": 1, "b": 2}}, {"name": "db"}]}}), box2
+
+        # Non-dict elements at a shared index are overwritten
+        box3 = Box({"nums": [1, 2, 3]})
+        box3.merge_update({"nums": [9, 8]}, box_merge_lists="merge")
+        assert box3.nums == [9, 8, 3]
+
+        # Falls back to assignment when the existing value is not a list
+        box4 = Box({"data": 5})
+        box4.merge_update({"data": [{"a": 1}]}, box_merge_lists="merge")
+        assert box4 == Box({"data": [{"a": 1}]}), box4
+
     def test_box_from_empty_yaml(self):
         out = Box.from_yaml("---")
         assert out == Box()


### PR DESCRIPTION
This adds a "merge" value for the existing box_merge_lists keyword so merge_update can combine lists of dictionaries element by element instead of replacing the whole list, which is what #263 asked for.

Right now box_merge_lists handles the two list-level strategies, extend and unique, but nested dictionaries buried inside a list still get dropped on merge. With this option merge_update walks both lists by index: when the same position holds a dict on each side it recurses (reusing merge_update so it keeps working at any depth), otherwise the incoming value wins, and any extra incoming elements are appended. The default behavior is unchanged since this only kicks in when you explicitly pass box_merge_lists="merge".

Using the example from the issue:

    >>> a = Box({"data": [{"foo": 1, "foobar": 20}, {"bar": 2}]})
    >>> a.merge_update({"data": [{"foo": 1, "baz": 10}]}, box_merge_lists="merge")
    >>> a
    Box({"data": [{"foo": 1, "foobar": 20, "baz": 10}, {"bar": 2}]})

I added a docstring to merge_update covering all the list modes, tests for the happy and sad paths, and CHANGES/AUTHORS entries.