### PR TITLE
Preserve configuration when copying ConfigBox

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -98,3 +98,5 @@ Suggestions and bug reporting:
 - d00m514y3r
 - Sébastien Weber (seb5g)
 - Ward Loos (wrdls)
+
+- oyeong011

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Preserve ConfigBox options when copying, including frozen_box and default_box.
+
 Version 7.4.1
 -------------
 

--- a/box/box.py
+++ b/box/box.py
@@ -471,7 +471,7 @@ class Box(dict):
     def copy(self) -> Box:
         config = self.__box_config()
         config.pop("box_namespace")  # Detach namespace; it will be reassigned if we nest again
-        return self.__class__(super().copy(), **config)
+        return Box(super().copy(), **config)
 
     def __copy__(self) -> Box:
         return self.copy()

--- a/box/box.py
+++ b/box/box.py
@@ -471,7 +471,7 @@ class Box(dict):
     def copy(self) -> Box:
         config = self.__box_config()
         config.pop("box_namespace")  # Detach namespace; it will be reassigned if we nest again
-        return Box(super().copy(), **config)
+        return self.__class__(super().copy(), **config)
 
     def __copy__(self) -> Box:
         return self.copy()

--- a/box/config_box.py
+++ b/box/config_box.py
@@ -125,9 +125,3 @@ class ConfigBox(Box):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self.to_dict())})"
-
-    def copy(self):
-        return ConfigBox(super().copy())
-
-    def __copy__(self):
-        return ConfigBox(super().copy())

--- a/box/config_box.py
+++ b/box/config_box.py
@@ -125,3 +125,14 @@ class ConfigBox(Box):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self.to_dict())})"
+
+    def copy(self):
+        config = {
+            key: value
+            for key, value in self._box_config.items()
+            if not key.startswith("__") and key != "box_namespace"
+        }
+        return ConfigBox(super().copy(), **config)
+
+    def __copy__(self):
+        return ConfigBox.copy(self)

--- a/test/test_config_box.py
+++ b/test/test_config_box.py
@@ -71,3 +71,27 @@ def test_copy_preserves_default_config(copier):
     copied = copier(original)
     assert copied.missing == 7
     assert "missing" not in original
+
+
+@pytest.mark.parametrize("copier", [copy, lambda value: value.copy()])
+@pytest.mark.parametrize("base", [Box, ConfigBox])
+def test_copy_preserves_base_type_for_subclass_with_required_argument(copier, base):
+    class CustomBox(base):
+        def __init__(self, required, **kwargs):
+            super().__init__(value=required, **kwargs)
+
+    original = CustomBox(1, frozen_box=True)
+    copied = copier(original)
+    assert type(copied) is base
+    assert copied.value == 1
+    assert copied is not original
+    with pytest.raises(BoxError):
+        copied.value = 2
+
+
+@pytest.mark.parametrize("copier", [copy, lambda value: value.copy()])
+def test_config_copy_detaches_namespace_and_hides_internal_config(copier):
+    original = ConfigBox(value=1, box_namespace=("parent",))
+    copied = copier(original)
+    assert copied == {"value": 1}
+    assert copied._box_config["box_namespace"] == ()

--- a/test/test_config_box.py
+++ b/test/test_config_box.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from copy import copy
+
+import pytest
+
 from test.common import test_dict
 
-from box import Box, ConfigBox
+from box import Box, BoxError, ConfigBox
 
 
 class TestConfigBox:
@@ -49,3 +53,21 @@ class TestConfigBox:
     def test_config_default(self):
         bx4 = Box(default_box=True, default_box_attr=ConfigBox)
         assert isinstance(bx4.bbbbb, ConfigBox)
+
+
+@pytest.mark.parametrize("copier", [copy, lambda value: value.copy()])
+def test_copy_preserves_frozen_config(copier):
+    original = ConfigBox(value=1, frozen_box=True)
+    copied = copier(original)
+    assert isinstance(copied, ConfigBox)
+    assert copied is not original
+    with pytest.raises(BoxError):
+        copied.value = 2
+
+
+@pytest.mark.parametrize("copier", [copy, lambda value: value.copy()])
+def test_copy_preserves_default_config(copier):
+    original = ConfigBox(default_box=True, default_box_attr=7)
+    copied = copier(original)
+    assert copied.missing == 7
+    assert "missing" not in original


### PR DESCRIPTION
Copying a ConfigBox currently discards options such as frozen_box and default_box, so a frozen copy becomes writable and default-value lookups stop working.

Preserve the ConfigBox configuration while excluding internal bookkeeping and detaching its namespace. Generic Box.copy keeps its existing behavior, including for subclasses with required constructor arguments; ConfigBox subclasses still copy to ConfigBox.

Validation: 169 tests passed on Python 3.14, including copy/copy.copy frozen/default regressions, constructor compatibility, namespace detachment and internal-key exclusion. Public API QA also passes. Cython and the remaining interpreter matrix were not run.

AI assistance: OpenAI Codex prepared the change and regression tests.
